### PR TITLE
Improve packages README and bump version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.1.4",
+      "version": "5.1.5",
       "commands": [
         "fantomas"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [*.fs]
+max_line_length=160
 fsharp_space_before_lowercase_invocation = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 
 env:
-  VERSION: 2.1.2
+  VERSION: 2.1.3
   CONFIG: Release
   SLN_FILE: Fabulous.XamarinForms.NoSamples.sln
   TEMPLATE_PROJ: templates/Fabulous.XamarinForms.Templates.proj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [2.1.3] - 2023-01-04
+
+### Changed
+- Updated README file included in the packages
+
 ## [2.1.2] - 2023-01-04
 
 ### Changed
@@ -19,6 +24,7 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms has moved from the Fabulous repository to its own repository: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.2...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.3...HEAD
+[2.1.3]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/fabulous-dev/Fabulous.XamarinForms/releases/tag/v2.1.1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can start your new Fabulous.XamarinForms app in a matter of seconds using th
 For a starter guide see our [documentation](https://docs.fabulous.dev/v2/xamarin.forms/getting-started).
 
 ```sh
-dotnet new -i Fabulous.XamarinForms.Templates
+dotnet new install Fabulous.XamarinForms.Templates
 dotnet new fabulous-xf -n MyApp
 ```
 

--- a/docs/1.x/docs/getting-started.md
+++ b/docs/1.x/docs/getting-started.md
@@ -19,7 +19,7 @@ toc: true
 1. Open a command prompt window and install the template pack by entering:
 
 ```sh
-dotnet new -i Fabulous.XamarinForms.Templates
+dotnet new install Fabulous.XamarinForms.Templates
 ```
 
 1. Navigate to a folder in the command prompt window where your new app can be created and enter:

--- a/docs/2.x/docs/getting-started/index.md
+++ b/docs/2.x/docs/getting-started/index.md
@@ -35,7 +35,7 @@ First, we need to install the latest templates for Fabulous. This is done via co
 Open a terminal in the folder where you want to store the new solution, and type the following command:
 
 ```sh
-dotnet new -i Fabulous.XamarinForms.Templates
+dotnet new install Fabulous.XamarinForms.Templates
 ```
 
 This will add Fabulous.XamarinForms to the templates available for `dotnet new`.

--- a/docs/2.x/docs/tutorials/using-nightly-builds.md
+++ b/docs/2.x/docs/tutorials/using-nightly-builds.md
@@ -49,7 +49,7 @@ It's the same than above, except you'll need to create `nuget.config` first so t
 Once you configured `nuget.config`, you can run
 
 ```sh
-dotnet new -i Fabulous.XamarinForms.Templates::XYZ
+dotnet new install Fabulous.XamarinForms.Templates::XYZ
 ```
 
 where `XYZ` is the latest version from [Fabulous.XamarinForms.Templates versions](https://github.com/fabulous-dev/Fabulous/packages/1334656/versions).

--- a/samples/CounterApp/Android.Mono/MainActivity.fs
+++ b/samples/CounterApp/Android.Mono/MainActivity.fs
@@ -14,8 +14,7 @@ open Xamarin.Forms.Platform.Android
            Icon = "@drawable/icon",
            Theme = "@style/MainTheme",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation))>]
+           ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -29,11 +28,6 @@ type MainActivity() =
 
         this.LoadApplication(Program.startApplication App.program)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/samples/CounterApp/CounterApp/App.fs
+++ b/samples/CounterApp/CounterApp/App.fs
@@ -7,9 +7,7 @@ open type Fabulous.XamarinForms.View
 
 module App =
     type Model =
-        { Count: int
-          Step: int
-          TimerOn: bool }
+        { Count: int; Step: int; TimerOn: bool }
 
     type Msg =
         | Increment
@@ -32,22 +30,14 @@ module App =
 
     let update msg model =
         match msg with
-        | Increment ->
-            { model with
-                  Count = model.Count + model.Step },
-            Cmd.none
-        | Decrement ->
-            { model with
-                  Count = model.Count - model.Step },
-            Cmd.none
+        | Increment -> { model with Count = model.Count + model.Step }, Cmd.none
+        | Decrement -> { model with Count = model.Count - model.Step }, Cmd.none
         | Reset -> initModel, Cmd.none
         | SetStep n -> { model with Step = int(n + 0.5) }, Cmd.none
         | TimerToggled on -> { model with TimerOn = on }, (if on then timerCmd() else Cmd.none)
         | TimedTick ->
             if model.TimerOn then
-                { model with
-                      Count = model.Count + model.Step },
-                timerCmd()
+                { model with Count = model.Count + model.Step }, timerCmd()
             else
                 model, Cmd.none
 
@@ -66,17 +56,16 @@ module App =
                         Label("Timer")
 
                         Switch(model.TimerOn, TimerToggled)
-                     })
+                    })
                         .padding(20.)
                         .centerHorizontal()
 
                     Slider(0.0, 10.0, double model.Step, SetStep)
 
-                    Label($"Step size: %d{model.Step}")
-                        .centerTextHorizontal()
+                    Label($"Step size: %d{model.Step}").centerTextHorizontal()
 
                     Button("Reset", Reset)
-                 })
+                })
                     .padding(30.)
                     .centerVertical()
             )

--- a/samples/FabulousContacts/Android.Mono/MainActivity.fs
+++ b/samples/FabulousContacts/Android.Mono/MainActivity.fs
@@ -27,11 +27,12 @@ do ()
            Icon = "@drawable/icon",
            Theme = "@style/FabulousContactsTheme.Splash",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation
-                                   ||| ConfigChanges.UiMode
-                                   ||| ConfigChanges.ScreenLayout
-                                   ||| ConfigChanges.SmallestScreenSize))>]
+           ConfigurationChanges =
+               (ConfigChanges.ScreenSize
+                ||| ConfigChanges.Orientation
+                ||| ConfigChanges.UiMode
+                ||| ConfigChanges.ScreenLayout
+                ||| ConfigChanges.SmallestScreenSize))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -57,16 +58,10 @@ type MainActivity() =
 
         let dbPath = getDbPath()
 
-        let application =
-            Program.startApplicationWithArgs dbPath App.program
+        let application = Program.startApplicationWithArgs dbPath App.program
 
         this.LoadApplication(application)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/samples/FabulousContacts/FabulousContacts/AboutPage.fs
+++ b/samples/FabulousContacts/FabulousContacts/AboutPage.fs
@@ -20,8 +20,7 @@ module AboutPage =
     let fabulousXamarinFormsUrl =
         "https://github.com/fabulous-dev/Fabulous/tree/master/Fabulous.XamarinForms"
 
-    let freepikUrl =
-        "https://www.flaticon.com/authors/freepik"
+    let freepikUrl = "https://www.flaticon.com/authors/freepik"
 
     let xamarinEssentialsUrl = "https://github.com/xamarin/Essentials"
     let authorBlogUrl = "https://timothelariviere.com"
@@ -35,11 +34,7 @@ module AboutPage =
     type Msg = OpenBrowser of string
 
     let openBrowserCmd url =
-        async {
-            do!
-                Browser.OpenAsync(Uri url, BrowserLaunchMode.SystemPreferred)
-                |> Async.AwaitTask
-        }
+        async { do! Browser.OpenAsync(Uri url, BrowserLaunchMode.SystemPreferred) |> Async.AwaitTask }
         |> Async.executeOnMainThread
         |> Cmd.performAsync
 
@@ -61,10 +56,7 @@ module AboutPage =
 
             Label(Strings.AboutPage_AboutFabulousContacts_Description)
 
-            UnderlinedLabel(
-                fabulousContactsRepositoryUrl
-            )
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser fabulousContactsRepositoryUrl) }
+            UnderlinedLabel(fabulousContactsRepositoryUrl).gestureRecognizers() { TapGestureRecognizer(openBrowser fabulousContactsRepositoryUrl) }
         }
 
     let aboutFSharp (openBrowser: string -> Msg) =
@@ -72,22 +64,22 @@ module AboutPage =
             Label(Strings.AboutPage_AboutFSharp_MadeWith)
 
             (VStack() {
-                Image(Aspect.AspectFit, "fsharp.png")
-                    .size(height = 50., width = 50.)
+                Image(Aspect.AspectFit, "fsharp.png").size(height = 50., width = 50.)
 
-                Label(Strings.AboutPage_AboutFSharp_FSharp)
-                    .centerTextHorizontal()
-             })
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser fsharpOrgUrl) }
+                Label(Strings.AboutPage_AboutFSharp_FSharp).centerTextHorizontal()
+            })
+                .gestureRecognizers() {
+                TapGestureRecognizer(openBrowser fsharpOrgUrl)
+            }
 
             (VStack() {
-                Image(Aspect.AspectFit, "xamarin.png")
-                    .size(height = 50., width = 50.)
+                Image(Aspect.AspectFit, "xamarin.png").size(height = 50., width = 50.)
 
-                Label(Strings.AboutPage_AboutFSharp_FabulousXamarinForms)
-                    .centerTextHorizontal()
-             })
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser fabulousXamarinFormsUrl) }
+                Label(Strings.AboutPage_AboutFSharp_FabulousXamarinForms).centerTextHorizontal()
+            })
+                .gestureRecognizers() {
+                TapGestureRecognizer(openBrowser fabulousXamarinFormsUrl)
+            }
         }
 
     let credits (openBrowser: string -> Msg) =
@@ -96,15 +88,12 @@ module AboutPage =
                 .font(attributes = FontAttributes.Bold)
                 .margin(Thickness(0., 20., 0., 0.))
 
-            UnderlinedLabel(
-                Strings.AboutPage_Credits_Freepik
-            )
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser freepikUrl) }
+            UnderlinedLabel(Strings.AboutPage_Credits_Freepik).gestureRecognizers() { TapGestureRecognizer(openBrowser freepikUrl) }
 
-            UnderlinedLabel(
-                Strings.AboutPage_Credits_XamarinEssentials
-            )
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser xamarinEssentialsUrl) }
+            UnderlinedLabel(Strings.AboutPage_Credits_XamarinEssentials)
+                .gestureRecognizers() {
+                TapGestureRecognizer(openBrowser xamarinEssentialsUrl)
+            }
         }
 
     let aboutAuthor (openBrowser: string -> Msg) =
@@ -116,42 +105,44 @@ module AboutPage =
             Label(Strings.AboutPage_AboutAuthor_AuthorName)
 
             (HStack(spacing = 15.) {
-                Image(Aspect.AspectFit, "blog.png")
-                    .size(height = 35., width = 35.)
+                Image(Aspect.AspectFit, "blog.png").size(height = 35., width = 35.)
 
                 UnderlinedLabel(authorBlogUrl).centerVertical()
-             })
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser authorBlogUrl) }
+            })
+                .gestureRecognizers() {
+                TapGestureRecognizer(openBrowser authorBlogUrl)
+            }
 
-            Label(Strings.AboutPage_AboutAuthor_ReachOut)
-                .margin(Thickness(0., 10., 0., 0.))
+            Label(Strings.AboutPage_AboutAuthor_ReachOut).margin(Thickness(0., 10., 0., 0.))
 
             (HStack(spacing = 15.) {
-                Image(Aspect.AspectFit, "github.png")
-                    .size(height = 35., width = 35.)
+                Image(Aspect.AspectFit, "github.png").size(height = 35., width = 35.)
 
-                UnderlinedLabel(authorGitHubHandle)
-                    .centerVertical()
-             })
-                .gestureRecognizers() { TapGestureRecognizer(openBrowser authorGitHubUrl) }
+                UnderlinedLabel(authorGitHubHandle).centerVertical()
+            })
+                .gestureRecognizers() {
+                TapGestureRecognizer(openBrowser authorGitHubUrl)
+            }
 
             (HStack(spacing = 15.) {
                 (VStack() {
-                    Image(Aspect.AspectFit, "twitter.png")
-                        .size(height = 50., width = 50.)
+                    Image(Aspect.AspectFit, "twitter.png").size(height = 50., width = 50.)
 
                     Label(authorTwitterHandle).centerTextHorizontal()
-                 })
-                    .gestureRecognizers() { TapGestureRecognizer(openBrowser authorTwitterUrl) }
+                })
+                    .gestureRecognizers() {
+                    TapGestureRecognizer(openBrowser authorTwitterUrl)
+                }
 
                 (VStack() {
-                    Image(Aspect.AspectFit, "slack.png")
-                        .size(height = 50., width = 50.)
+                    Image(Aspect.AspectFit, "slack.png").size(height = 50., width = 50.)
 
                     Label(authorSlackHandle).centerTextHorizontal()
-                 })
-                    .gestureRecognizers() { TapGestureRecognizer(openBrowser authorSlackUrl) }
-             })
+                })
+                    .gestureRecognizers() {
+                    TapGestureRecognizer(openBrowser authorSlackUrl)
+                }
+            })
                 .centerHorizontal()
                 .margin(Thickness(0., 10., 0., 0.))
         }
@@ -171,7 +162,7 @@ module AboutPage =
                     aboutFSharp OpenBrowser
                     credits OpenBrowser
                     aboutAuthor OpenBrowser
-                 })
+                })
                     .padding(Thickness(20., 10., 20., 20.))
             )
         )

--- a/samples/FabulousContacts/FabulousContacts/App.fs
+++ b/samples/FabulousContacts/FabulousContacts/App.fs
@@ -75,39 +75,30 @@ module App =
             let m, cmd, externalMsg = MainPage.update msg model.MainPageModel
             let cmd2 = handleMainExternalMsg externalMsg
 
-            let batchCmd =
-                Cmd.batch [ (Cmd.map MainPageMsg cmd)
-                            cmd2 ]
+            let batchCmd = Cmd.batch [ (Cmd.map MainPageMsg cmd); cmd2 ]
 
             { model with MainPageModel = m }, batchCmd
 
         | DetailPageMsg msg ->
-            let m, cmd, externalMsg =
-                DetailPage.update msg model.DetailPageModel.Value
+            let m, cmd, externalMsg = DetailPage.update msg model.DetailPageModel.Value
 
             let cmd2 = handleDetailPageExternalMsg externalMsg
 
-            let batchCmd =
-                Cmd.batch [ (Cmd.map DetailPageMsg cmd)
-                            cmd2 ]
+            let batchCmd = Cmd.batch [ (Cmd.map DetailPageMsg cmd); cmd2 ]
 
             { model with DetailPageModel = Some m }, batchCmd
 
         | EditPageMsg msg ->
-            let m, cmd, externalMsg =
-                EditPage.update model.DbPath msg model.EditPageModel.Value
+            let m, cmd, externalMsg = EditPage.update model.DbPath msg model.EditPageModel.Value
 
             let cmd2 = handleEditPageExternalMsg externalMsg
 
-            let batchCmd =
-                Cmd.batch [ (Cmd.map EditPageMsg cmd)
-                            cmd2 ]
+            let batchCmd = Cmd.batch [ (Cmd.map EditPageMsg cmd); cmd2 ]
 
             { model with EditPageModel = Some m }, batchCmd
 
         | AboutPageMsg msg ->
-            let m, cmd =
-                AboutPage.update msg model.AboutPageModel.Value
+            let m, cmd = AboutPage.update msg model.AboutPageModel.Value
 
             { model with AboutPageModel = Some m }, Cmd.map AboutPageMsg cmd
 
@@ -124,8 +115,7 @@ module App =
             { model with EditPageModel = Some m }, (Cmd.map EditPageMsg cmd)
 
         | UpdateWhenContactAdded contact ->
-            let mainMsg =
-                Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactAdded contact))
+            let mainMsg = Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactAdded contact))
 
             let m = { model with EditPageModel = None }
 
@@ -133,21 +123,21 @@ module App =
 
         | UpdateWhenContactUpdated contact ->
             let pendingCmds =
-                Cmd.batch [ Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactUpdated contact))
-                            Cmd.ofMsg(DetailPageMsg(DetailPage.Msg.ContactUpdated contact)) ]
+                Cmd.batch
+                    [ Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactUpdated contact))
+                      Cmd.ofMsg(DetailPageMsg(DetailPage.Msg.ContactUpdated contact)) ]
 
             let m = { model with EditPageModel = None }
 
             m, pendingCmds
 
         | UpdateWhenContactDeleted contact ->
-            let mainMsg =
-                Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactDeleted contact))
+            let mainMsg = Cmd.ofMsg(MainPageMsg(MainPage.Msg.ContactDeleted contact))
 
             let m =
                 { model with
-                      DetailPageModel = None
-                      EditPageModel = None }
+                    DetailPageModel = None
+                    EditPageModel = None }
 
             m, mainMsg
 
@@ -167,7 +157,7 @@ module App =
                 match model.EditPageModel with
                 | None -> ()
                 | Some editModel -> View.map EditPageMsg (EditPage.view editModel)
-             })
+            })
                 .barTextColor(Style.accentTextColor)
                 .barBackgroundColor(Style.accentColor)
                 .onBackNavigated(BackNavigated)

--- a/samples/FabulousContacts/FabulousContacts/Components.fs
+++ b/samples/FabulousContacts/FabulousContacts/Components.fs
@@ -12,14 +12,10 @@ open System.IO
 
 module Components =
     let centralLabel text =
-        Label(text)
-            .centerHorizontal()
-            .centerVertical(expand = true)
+        Label(text).centerHorizontal().centerVertical(expand = true)
 
     let formLabel text =
-        View
-            .Label(text)
-            .margin(Thickness(0., 20., 0., 5.))
+        View.Label(text).margin(Thickness(0., 20., 0., 5.))
 
     let formEntry placeholder text keyboard isValid onTextChanged =
         BorderedEntry(text, onTextChanged)
@@ -43,8 +39,7 @@ module Components =
             .alignEndVertical(expand = true)
 
     let toolbarButton text onClicked =
-        ToolbarItem(text, onClicked)
-            .order(ToolbarItemOrder.Primary)
+        ToolbarItem(text, onClicked).order(ToolbarItemOrder.Primary)
 
     let groupView name =
         ViewCell(
@@ -54,7 +49,7 @@ module Components =
                     .verticalOptions(LayoutOptions.FillAndExpand)
                     .verticalTextAlignment(TextAlignment.Center)
                     .margin(Thickness(20., 5.))
-             })
+            })
                 .background(accentColor)
         )
 
@@ -66,16 +61,13 @@ module Components =
                     .size(height = 50., width = 50.)
 
                 (VStack(spacing = 5.) {
-                    Label(name)
-                        .font(18.)
-                        .fillVertical(expand = true)
-                        .centerTextVertical()
+                    Label(name).font(18.).fillVertical(expand = true).centerTextVertical()
 
                     Label(address)
                         .font(12.)
                         .textColor(Color.Gray.ToFabColor())
                         .lineBreakMode(LineBreakMode.TailTruncation)
-                 })
+                })
                     .fillHorizontal(expand = true)
                     .margin(0., 5., 0., 5.)
 
@@ -84,7 +76,7 @@ module Components =
                     .centerVertical()
                     .margin(0., 0., 15., 0.)
                     .size(height = 25., width = 25.)
-             })
+            })
                 .padding(5.)
         )
 
@@ -95,29 +87,24 @@ module Components =
             .fillHorizontal(expand = true)
 
     let detailFieldTitle text =
-        Label(text)
-            .font(attributes = FontAttributes.Bold)
-            .margin(0., 10., 0., 0.)
+        Label(text).font(attributes = FontAttributes.Bold).margin(0., 10., 0., 0.)
 
     let optionalLabel text =
         match text with
-        | "" ->
-            Label(Strings.Common_NotSpecified)
-                .font(attributes = FontAttributes.Italic)
+        | "" -> Label(Strings.Common_NotSpecified).font(attributes = FontAttributes.Italic)
         | _ -> Label(text)
 
     let favoriteField isFavorite markAsFavorite =
         (HStack() {
-            Label(Strings.EditPage_MarkAsFavoriteField_Label)
-                .centerVertical()
+            Label(Strings.EditPage_MarkAsFavoriteField_Label).centerVertical()
 
             Switch(isFavorite, markAsFavorite)
                 .alignEndHorizontal(expand = true)
                 .centerVertical()
-         })
+        })
             .margin(0., 20., 0., 0.)
 
-    let profilePictureButton (picture: byte [] option) updatePicture =
+    let profilePictureButton (picture: byte[] option) updatePicture =
         match picture with
         | None ->
             ContentView(ImageButton(Aspect.AspectFit, "addphoto.png", updatePicture))
@@ -125,10 +112,8 @@ module Components =
                 .gridRowSpan(2)
 
         | Some picture ->
-            ContentView(
-                Image(Aspect.AspectFill, new MemoryStream(picture))
-            )
-                .gridRowSpan(
-                2
-            )
-                .gestureRecognizers() { TapGestureRecognizer(updatePicture) }
+            ContentView(Image(Aspect.AspectFill, new MemoryStream(picture)))
+                .gridRowSpan(2)
+                .gestureRecognizers() {
+                TapGestureRecognizer(updatePicture)
+            }

--- a/samples/FabulousContacts/FabulousContacts/ContactsListPage.fs
+++ b/samples/FabulousContacts/FabulousContacts/ContactsListPage.fs
@@ -60,7 +60,9 @@ module ContactsListPage =
             i <- i - 1
 
             for contact in group do
-                if i = 0 then foundContact <- contact
+                if i = 0 then
+                    foundContact <- contact
+
                 i <- i - 1
 
         foundContact
@@ -84,8 +86,8 @@ module ContactsListPage =
 
             let m =
                 { model with
-                      FilterText = filterText
-                      ContactGroups = contactGroups }
+                    FilterText = filterText
+                    ContactGroups = contactGroups }
 
             m, Cmd.none, ExternalMsg.NoOp
 
@@ -94,8 +96,8 @@ module ContactsListPage =
 
             let m =
                 { model with
-                      Contacts = contacts
-                      ContactGroups = contactGroups }
+                    Contacts = contacts
+                    ContactGroups = contactGroups }
 
             m, Cmd.none, ExternalMsg.NoOp
 
@@ -113,40 +115,33 @@ module ContactsListPage =
                     .background(accentColor)
                     .cancelButtonColor(accentTextColor)
 
-                (ListView
-                    (model.Contacts)
-                    (fun contact ->
-                        cellView
-                            contact.Picture
-                            $"{contact.FirstName} {contact.LastName}"
-                            contact.Address
-                            contact.IsFavorite))
+                (ListView (model.Contacts) (fun contact -> cellView contact.Picture $"{contact.FirstName} {contact.LastName}" contact.Address contact.IsFavorite))
                     .rowHeight(60)
                     .selectionMode(ListViewSelectionMode.None)
                     .onItemTapped(ContactSelected)
                     .fillVertical(expand = true)
 
-             // TODO: For some reason, the GroupedListView triggers a native crash on Android but works perfectly on iOS.
-             // GroupedListView
-             //     model.ContactGroups
-             //     (fun group ->
-             //         TextCell("Hello")
-             //         // groupView group.Name
-             //     )
-             //     (fun contact ->
-             //         TextCell("Hello")
-             //         // cellView
-             //         //     contact.Picture
-             //         //     $"{contact.FirstName} {contact.LastName}"
-             //         //     contact.Address
-             //         //     contact.IsFavorite
-             //     )
-             //
-             //     // .rowHeight(60)
-             //     // .selectionMode(ListViewSelectionMode.None)
-             //     // .onItemTapped(ContactSelected)
-             //     // .fillVertical(expand = true)
-             })
+            // TODO: For some reason, the GroupedListView triggers a native crash on Android but works perfectly on iOS.
+            // GroupedListView
+            //     model.ContactGroups
+            //     (fun group ->
+            //         TextCell("Hello")
+            //         // groupView group.Name
+            //     )
+            //     (fun contact ->
+            //         TextCell("Hello")
+            //         // cellView
+            //         //     contact.Picture
+            //         //     $"{contact.FirstName} {contact.LastName}"
+            //         //     contact.Address
+            //         //     contact.IsFavorite
+            //     )
+            //
+            //     // .rowHeight(60)
+            //     // .selectionMode(ListViewSelectionMode.None)
+            //     // .onItemTapped(ContactSelected)
+            //     // .fillVertical(expand = true)
+            })
         )
             .toolbarItems() {
             ToolbarItem(Strings.Common_About, AboutTapped)

--- a/samples/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
+++ b/samples/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
@@ -21,18 +21,16 @@ type IBorderedEntry =
 module BorderedEntry =
     let WidgetKey = Widgets.register<BorderedEntry>()
 
-    let BorderColor =
-        Attributes.defineBindableColor BorderedEntry.BorderColorProperty
+    let BorderColor = Attributes.defineBindableColor BorderedEntry.BorderColorProperty
 
 [<AutoOpen>]
 module EntryBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline BorderedEntry<'msg>(text, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IBorderedEntry>(
                 BorderedEntry.WidgetKey,
-                InputView.TextWithEvent.WithValue(
-                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
-                )
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
             )
 
 [<AutoOpen>]

--- a/samples/FabulousContacts/FabulousContacts/Controls/Map.fs
+++ b/samples/FabulousContacts/FabulousContacts/Controls/Map.fs
@@ -13,39 +13,31 @@ type IMap =
     inherit IView
 
 module Pin =
-    let PinType =
-        Attributes.defineBindableWithEquality<PinType> Pin.TypeProperty
+    let PinType = Attributes.defineBindableWithEquality<PinType> Pin.TypeProperty
 
-    let Label =
-        Attributes.defineBindableWithEquality<string> Pin.LabelProperty
+    let Label = Attributes.defineBindableWithEquality<string> Pin.LabelProperty
 
-    let Position =
-        Attributes.defineBindableWithEquality<Position> Pin.PositionProperty
+    let Position = Attributes.defineBindableWithEquality<Position> Pin.PositionProperty
 
-    let Address =
-        Attributes.defineBindableWithEquality<string> Pin.AddressProperty
+    let Address = Attributes.defineBindableWithEquality<string> Pin.AddressProperty
 
     let PinKey = Widgets.register<Pin>()
 
 module Map =
     let RequestedRegion =
-        Attributes.defineSimpleScalarWithEquality<MapSpan>
-            "Map_RequestedRegion"
-            (fun _ newValueOpt node ->
-                let map = node.Target :?> Map
+        Attributes.defineSimpleScalarWithEquality<MapSpan> "Map_RequestedRegion" (fun _ newValueOpt node ->
+            let map = node.Target :?> Map
 
-                match newValueOpt with
-                | ValueNone -> ()
-                | ValueSome mapSpan -> map.MoveToRegion(mapSpan))
+            match newValueOpt with
+            | ValueNone -> ()
+            | ValueSome mapSpan -> map.MoveToRegion(mapSpan))
 
     let Pins =
         Attributes.defineListWidgetCollection "Map_Pins" (fun target -> (target :?> Map).Pins)
 
-    let HasZoomEnabled =
-        Attributes.defineBindableBool Map.HasZoomEnabledProperty
+    let HasZoomEnabled = Attributes.defineBindableBool Map.HasZoomEnabledProperty
 
-    let HasScrollEnabled =
-        Attributes.defineBindableBool Map.HasScrollEnabledProperty
+    let HasScrollEnabled = Attributes.defineBindableBool Map.HasScrollEnabledProperty
 
     let MapKey = Widgets.register<Map>()
 
@@ -53,13 +45,9 @@ module Map =
 module MapBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline Pin<'msg>(pinType, label, position) =
-            WidgetBuilder<'msg, IPin>(
-                Pin.PinKey,
-                Pin.PinType.WithValue(pinType),
-                Pin.Label.WithValue(label),
-                Pin.Position.WithValue(position)
-            )
+            WidgetBuilder<'msg, IPin>(Pin.PinKey, Pin.PinType.WithValue(pinType), Pin.Label.WithValue(label), Pin.Position.WithValue(position))
 
         static member inline Map<'msg>(requestedRegion) =
             CollectionBuilder<'msg, IMap, IPin>(Map.MapKey, Map.Pins, Map.RequestedRegion.WithValue(requestedRegion))

--- a/samples/FabulousContacts/FabulousContacts/Controls/UnderlinedLabel.fs
+++ b/samples/FabulousContacts/FabulousContacts/Controls/UnderlinedLabel.fs
@@ -15,5 +15,6 @@ module FabulousUnderlinedLabel =
         inherit ILabel
 
     type Fabulous.XamarinForms.View with
+
         static member inline UnderlinedLabel<'msg>(text) =
             WidgetBuilder<'msg, IUnderlinedLabel>(UnderlinedLabelKey, Label.Text.WithValue(text))

--- a/samples/FabulousContacts/FabulousContacts/DetailPage.fs
+++ b/samples/FabulousContacts/FabulousContacts/DetailPage.fs
@@ -37,12 +37,7 @@ module DetailPage =
                 PhoneDialer.Open(phoneNumber)
             with
             | :? FeatureNotSupportedException ->
-                do!
-                    displayAlert(
-                        Strings.DetailPage_DialNumberFailed,
-                        Strings.DetailPage_CapabilityNotSupported "Phone Dialer",
-                        Strings.Common_OK
-                    )
+                do! displayAlert(Strings.DetailPage_DialNumberFailed, Strings.DetailPage_CapabilityNotSupported "Phone Dialer", Strings.Common_OK)
             | _ -> do! displayAlert(Strings.DetailPage_DialNumberFailed, Strings.Common_Error, Strings.Common_OK)
         }
         |> Async.executeOnMainThread
@@ -55,12 +50,7 @@ module DetailPage =
                 do! Sms.ComposeAsync(message) |> Async.AwaitTask
             with
             | :? FeatureNotSupportedException ->
-                do!
-                    displayAlert(
-                        Strings.DetailPage_ComposeSmsFailed,
-                        Strings.DetailPage_CapabilityNotSupported "SMS",
-                        Strings.Common_OK
-                    )
+                do! displayAlert(Strings.DetailPage_ComposeSmsFailed, Strings.DetailPage_CapabilityNotSupported "SMS", Strings.Common_OK)
             | _ -> do! displayAlert(Strings.DetailPage_ComposeSmsFailed, Strings.Common_Error, Strings.Common_OK)
         }
         |> Async.executeOnMainThread
@@ -73,12 +63,7 @@ module DetailPage =
                 do! Email.ComposeAsync(message) |> Async.AwaitTask
             with
             | :? FeatureNotSupportedException ->
-                do!
-                    displayAlert(
-                        Strings.DetailPage_ComposeEmailFailed,
-                        Strings.DetailPage_CapabilityNotSupported "Email",
-                        Strings.Common_OK
-                    )
+                do! displayAlert(Strings.DetailPage_ComposeEmailFailed, Strings.DetailPage_CapabilityNotSupported "Email", Strings.Common_OK)
             | _ -> do! displayAlert(Strings.DetailPage_ComposeEmailFailed, Strings.Common_Error, Strings.Common_OK)
         }
         |> Async.executeOnMainThread
@@ -117,7 +102,7 @@ module DetailPage =
                         .size(height = 35., width = 35.)
                         .alignStartHorizontal()
                         .alignStartVertical()
-                 })
+                })
                     .size(height = 125., width = 125.)
                     .background(Color.White.ToFabColor())
                     .centerHorizontal()
@@ -129,14 +114,14 @@ module DetailPage =
 
                     if hasSetField contact.Email then
                         detailActionButton "email.png" EmailTapped
-                 })
+                })
                     .centerHorizontal()
                     .margin(0., 10., 0., 10.)
-             })
+            })
                 .background(FabColor.fromHex "#448cb8")
                 .padding(20., 10., 20., 10.)
-        with
-        | ex -> raise ex
+        with ex ->
+            raise ex
 
     let body contact =
         (VStack(spacing = 10.) {
@@ -146,7 +131,7 @@ module DetailPage =
             optionalLabel contact.Phone
             detailFieldTitle "Address"
             optionalLabel contact.Address
-         })
+        })
             .padding(20., 10., 20., 20.)
 
     let view model =

--- a/samples/FabulousContacts/FabulousContacts/EditPage.fs
+++ b/samples/FabulousContacts/FabulousContacts/EditPage.fs
@@ -57,15 +57,9 @@ module EditPage =
     let tryDeleteAsync dbPath (contact: Contact) =
         async {
             let! shouldDelete =
-                let title =
-                    Strings.EditPage_DeleteContact contact.FirstName contact.LastName
+                let title = Strings.EditPage_DeleteContact contact.FirstName contact.LastName
 
-                displayAlertWithConfirm(
-                    title,
-                    Strings.EditPage_DeleteContactConfirmation,
-                    Strings.Common_Yes,
-                    Strings.Common_No
-                )
+                displayAlertWithConfirm(title, Strings.EditPage_DeleteContactConfirmation, Strings.Common_Yes, Strings.Common_No)
 
             if shouldDelete then
                 do! deleteContact dbPath contact
@@ -95,8 +89,7 @@ module EditPage =
     let tryUpdatePictureAsync (previousValue: _ option) =
         async {
             let canTakePicture =
-                CrossMedia.Current.IsCameraAvailable
-                && CrossMedia.Current.IsTakePhotoSupported
+                CrossMedia.Current.IsCameraAvailable && CrossMedia.Current.IsTakePhotoSupported
 
             let canPickPicture = CrossMedia.Current.IsPickPhotoSupported
 
@@ -110,10 +103,11 @@ module EditPage =
                          Some Strings.EditPage_PictureContextMenu_Remove
                      else
                          None),
-                    Some [| if canTakePicture then
-                                yield Strings.EditPage_PictureContextMenu_TakePicture
-                            if canPickPicture then
-                                yield Strings.EditPage_PictureContextMenu_ChooseFromGallery |]
+                    Some
+                        [| if canTakePicture then
+                               yield Strings.EditPage_PictureContextMenu_TakePicture
+                           if canPickPicture then
+                               yield Strings.EditPage_PictureContextMenu_ChooseFromGallery |]
                 )
 
             let setPicture value = Some(SetPicture value)
@@ -132,14 +126,7 @@ module EditPage =
         |> Cmd.ofAsyncMsgOption
 
     let sayContactNotValidAsync () =
-        async {
-            do!
-                displayAlert(
-                    Strings.EditPage_InvalidContactTitle,
-                    Strings.EditPage_InvalidContactDescription,
-                    Strings.Common_OK
-                )
-        }
+        async { do! displayAlert(Strings.EditPage_InvalidContactTitle, Strings.EditPage_InvalidContactDescription, Strings.Common_OK) }
 
     let createOrUpdateAsync dbPath contact =
         async {
@@ -154,8 +141,7 @@ module EditPage =
 
     let trySaveAsync model dbPath =
         async {
-            if not model.IsFirstNameValid
-               || not model.IsLastNameValid then
+            if not model.IsFirstNameValid || not model.IsLastNameValid then
                 do! sayContactNotValidAsync()
                 return None
             else
@@ -218,16 +204,16 @@ module EditPage =
         | UpdateFirstName v ->
             let m =
                 { model with
-                      FirstName = v
-                      IsFirstNameValid = (validateFirstName v) }
+                    FirstName = v
+                    IsFirstNameValid = (validateFirstName v) }
 
             m, Cmd.none, ExternalMsg.NoOp
 
         | UpdateLastName v ->
             let m =
                 { model with
-                      LastName = v
-                      IsLastNameValid = (validateLastName v) }
+                    LastName = v
+                    IsLastNameValid = (validateLastName v) }
 
             m, Cmd.none, ExternalMsg.NoOp
 
@@ -261,8 +247,7 @@ module EditPage =
 
     let view model =
         let title =
-            let fullName =
-                $"%s{model.FirstName} %s{model.LastName}".Trim()
+            let fullName = $"%s{model.FirstName} %s{model.LastName}".Trim()
 
             match model.Contact, fullName.Trim() with
             | None, "" -> Strings.EditPage_Title_NewContact
@@ -276,25 +261,15 @@ module EditPage =
                     (Grid(coldefs = [ Absolute 100.; Star ], rowdefs = [ Absolute 50.; Absolute 50. ]) {
                         profilePictureButton model.Picture UpdatePicture
 
-                        (formEntry
-                            Strings.EditPage_FirstNameField_Label
-                            model.FirstName
-                            Keyboard.Text
-                            model.IsFirstNameValid
-                            UpdateFirstName)
+                        (formEntry Strings.EditPage_FirstNameField_Label model.FirstName Keyboard.Text model.IsFirstNameValid UpdateFirstName)
                             .centerVertical()
                             .gridColumn(1)
 
-                        (formEntry
-                            Strings.EditPage_LastNameField_Label
-                            model.LastName
-                            Keyboard.Text
-                            model.IsLastNameValid
-                            UpdateLastName)
+                        (formEntry Strings.EditPage_LastNameField_Label model.LastName Keyboard.Text model.IsLastNameValid UpdateLastName)
                             .centerVertical()
                             .gridColumn(1)
                             .gridRow(1)
-                     })
+                    })
                         .columnSpacing(10.)
                         .rowSpacing(0.)
 
@@ -310,8 +285,10 @@ module EditPage =
                     | None -> ()
                     | Some x when x.Id = 0 -> ()
                     | Some contact -> destroyButton Strings.EditPage_DeleteButtonText (DeleteContact contact)
-                 })
+                })
                     .padding(Thickness(20.))
             )
         )
-            .toolbarItems() { toolbarButton Strings.EditPage_Toolbar_SaveContact SaveContact }
+            .toolbarItems() {
+            toolbarButton Strings.EditPage_Toolbar_SaveContact SaveContact
+        }

--- a/samples/FabulousContacts/FabulousContacts/Helpers.fs
+++ b/samples/FabulousContacts/FabulousContacts/Helpers.fs
@@ -32,52 +32,40 @@ module Helpers =
     let requestPermissionAsync<'a when 'a: (new: unit -> 'a) and 'a :> BasePermission> () =
         async {
             try
-                let! status =
-                    CrossPermissions.Current.RequestPermissionAsync<'a>()
-                    |> Async.AwaitTask
+                let! status = CrossPermissions.Current.RequestPermissionAsync<'a>() |> Async.AwaitTask
 
-                return
-                    status = PermissionStatus.Granted
-                    || status = PermissionStatus.Unknown
-            with
-            | _ -> return false
+                return status = PermissionStatus.Granted || status = PermissionStatus.Unknown
+            with _ ->
+                return false
         }
 
     let askPermissionAsync<'a when 'a: (new: unit -> 'a) and 'a :> BasePermission> () =
         async {
             try
-                let! status =
-                    CrossPermissions.Current.CheckPermissionStatusAsync<'a>()
-                    |> Async.AwaitTask
+                let! status = CrossPermissions.Current.CheckPermissionStatusAsync<'a>() |> Async.AwaitTask
 
                 if status = PermissionStatus.Granted then
                     return true
                 else
                     return! requestPermissionAsync<'a>()
-            with
-            | _ -> return false
+            with _ ->
+                return false
         }
 
     let takePictureAsync () =
         async {
-            let options =
-                StoreCameraMediaOptions(PhotoSize = PhotoSize.Small)
+            let options = StoreCameraMediaOptions(PhotoSize = PhotoSize.Small)
 
-            let! picture =
-                CrossMedia.Current.TakePhotoAsync(options)
-                |> Async.AwaitTask
+            let! picture = CrossMedia.Current.TakePhotoAsync(options) |> Async.AwaitTask
 
             return picture |> Option.ofObj
         }
 
     let pickPictureAsync () =
         async {
-            let options =
-                PickMediaOptions(PhotoSize = PhotoSize.Small)
+            let options = PickMediaOptions(PhotoSize = PhotoSize.Small)
 
-            let! picture =
-                CrossMedia.Current.PickPhotoAsync(options)
-                |> Async.AwaitTask
+            let! picture = CrossMedia.Current.PickPhotoAsync(options) |> Async.AwaitTask
 
             return picture |> Option.ofObj
         }
@@ -87,14 +75,12 @@ module Helpers =
             use stream = file.GetStream()
             use memoryStream = new MemoryStream()
 
-            do!
-                stream.CopyToAsync(memoryStream)
-                |> Async.AwaitTask
+            do! stream.CopyToAsync(memoryStream) |> Async.AwaitTask
 
             return memoryStream.ToArray()
         }
 
-    let getImageValueOrDefault (defaultValue: string) aspect (value: byte [] option) =
+    let getImageValueOrDefault (defaultValue: string) aspect (value: byte[] option) =
         match value with
         | None -> Image(aspect, defaultValue)
         | Some bytes -> Image(aspect, new MemoryStream(bytes))

--- a/samples/FabulousContacts/FabulousContacts/MainPage.fs
+++ b/samples/FabulousContacts/FabulousContacts/MainPage.fs
@@ -54,10 +54,11 @@ module MainPage =
               TabMapModel = modelMap }
 
         let batchCmd =
-            Cmd.batch [ Cmd.ofAsyncMsg(loadAsync dbPath)
-                        Cmd.map TabAllContactsMsg msgAllContacts
-                        Cmd.map TabFavContactsMsg msgFavContacts
-                        Cmd.map TabMapMsg msgMap ]
+            Cmd.batch
+                [ Cmd.ofAsyncMsg(loadAsync dbPath)
+                  Cmd.map TabAllContactsMsg msgAllContacts
+                  Cmd.map TabFavContactsMsg msgFavContacts
+                  Cmd.map TabMapMsg msgMap ]
 
         m, batchCmd
 
@@ -70,17 +71,12 @@ module MainPage =
                 | ContactsListPage.ExternalMsg.NoOp -> Cmd.none, ExternalMsg.NoOp
                 | ContactsListPage.ExternalMsg.NavigateToAbout -> Cmd.none, ExternalMsg.NavigateToAbout
                 | ContactsListPage.ExternalMsg.NavigateToNewContact -> Cmd.none, ExternalMsg.NavigateToNewContact
-                | ContactsListPage.ExternalMsg.NavigateToDetail contact ->
-                    Cmd.none, (ExternalMsg.NavigateToDetail contact)
+                | ContactsListPage.ExternalMsg.NavigateToDetail contact -> Cmd.none, (ExternalMsg.NavigateToDetail contact)
 
-            m,
-            Cmd.batch [ Cmd.map mapMsgFunc cmd
-                        cmd2 ],
-            externalMsg2
+            m, Cmd.batch [ Cmd.map mapMsgFunc cmd; cmd2 ], externalMsg2
 
         let updateContacts model contacts =
-            let allMsg =
-                ContactsListPage.Msg.ContactsLoaded contacts
+            let allMsg = ContactsListPage.Msg.ContactsLoaded contacts
 
             let favMsg =
                 ContactsListPage.Msg.ContactsLoaded(contacts |> List.filter(fun c -> c.IsFavorite))
@@ -88,9 +84,10 @@ module MainPage =
             let mapMsg = MapPage.Msg.LoadPins contacts
 
             let batchCmd =
-                Cmd.batch [ Cmd.ofMsg(TabAllContactsMsg allMsg)
-                            Cmd.ofMsg(TabFavContactsMsg favMsg)
-                            Cmd.ofMsg(TabMapMsg mapMsg) ]
+                Cmd.batch
+                    [ Cmd.ofMsg(TabAllContactsMsg allMsg)
+                      Cmd.ofMsg(TabFavContactsMsg favMsg)
+                      Cmd.ofMsg(TabMapMsg mapMsg) ]
 
             let m = { model with Contacts = Some contacts }
             m, batchCmd, ExternalMsg.NoOp
@@ -126,9 +123,7 @@ module MainPage =
             updateContacts model newContacts
 
         | ContactDeleted contact ->
-            let newContacts =
-                model.Contacts.Value
-                |> List.filter(fun c -> c <> contact)
+            let newContacts = model.Contacts.Value |> List.filter(fun c -> c <> contact)
 
             updateContacts model newContacts
 
@@ -140,10 +135,7 @@ module MainPage =
         ContentPage(title, VStack() { centralLabel Strings.MainPage_Loading })
 
     let emptyView title =
-        ContentPage(
-            title,
-            VStack() { centralLabel Strings.MainPage_NoContact }
-        )
+        ContentPage(title, VStack() { centralLabel Strings.MainPage_NoContact })
             .toolbarItems() {
             ToolbarItem(Strings.Common_About, NoContactAboutTapped)
             ToolbarItem("+", NoContactAddNewContactTapped)
@@ -158,15 +150,13 @@ module MainPage =
             (ContactsListPage.view Strings.MainPage_TabFavoritesTitle model.TabFavContactsModel)
                 .icon("favoritetab.png")
 
-        let tabMap =
-            (MapPage.view model.TabMapModel)
-                .icon("maptab.png")
+        let tabMap = (MapPage.view model.TabMapModel).icon("maptab.png")
 
         (TabbedPage(title) {
             View.map TabAllContactsMsg tabAllContacts
             View.map TabAllContactsMsg tabFavContacts
             View.map TabMapMsg tabMap
-         })
+        })
             .toolbarPlacement(ToolbarPlacement.Bottom)
 
     let view model =

--- a/samples/FabulousContacts/FabulousContacts/Repository.fs
+++ b/samples/FabulousContacts/FabulousContacts/Repository.fs
@@ -40,13 +40,9 @@ module Repository =
 
     let connect dbPath =
         async {
-            let db =
-                SQLiteAsyncConnection(SQLiteConnectionString dbPath)
+            let db = SQLiteAsyncConnection(SQLiteConnectionString dbPath)
 
-            do!
-                db.CreateTableAsync<ContactObject>()
-                |> Async.AwaitTask
-                |> Async.Ignore
+            do! db.CreateTableAsync<ContactObject>() |> Async.AwaitTask |> Async.Ignore
 
             return db
         }
@@ -55,12 +51,9 @@ module Repository =
         async {
             let! database = connect dbPath
 
-            let! objs =
-                database.Table<ContactObject>().ToListAsync()
-                |> Async.AwaitTask
+            let! objs = database.Table<ContactObject>().ToListAsync() |> Async.AwaitTask
 
-            let results =
-                objs |> Seq.toList |> List.map convertToModel
+            let results = objs |> Seq.toList |> List.map convertToModel
 
             do! database.CloseAsync() |> Async.AwaitTask
 
@@ -72,10 +65,7 @@ module Repository =
             let! database = connect dbPath
             let obj = convertToObject contact
 
-            do!
-                database.InsertAsync(obj)
-                |> Async.AwaitTask
-                |> Async.Ignore
+            do! database.InsertAsync(obj) |> Async.AwaitTask |> Async.Ignore
 
             let! rowIdObj =
                 database.ExecuteScalarAsync("select last_insert_rowid()", [||])
@@ -93,10 +83,7 @@ module Repository =
             let! database = connect dbPath
             let obj = convertToObject contact
 
-            do!
-                database.UpdateAsync(obj)
-                |> Async.AwaitTask
-                |> Async.Ignore
+            do! database.UpdateAsync(obj) |> Async.AwaitTask |> Async.Ignore
 
             do! database.CloseAsync() |> Async.AwaitTask
 
@@ -108,10 +95,7 @@ module Repository =
             let! database = connect dbPath
             let obj = convertToObject contact
 
-            do!
-                database.DeleteAsync(obj)
-                |> Async.AwaitTask
-                |> Async.Ignore
+            do! database.DeleteAsync(obj) |> Async.AwaitTask |> Async.Ignore
 
             do! database.CloseAsync() |> Async.AwaitTask
         }

--- a/samples/FabulousContacts/FabulousContacts/Strings.fs
+++ b/samples/FabulousContacts/FabulousContacts/Strings.fs
@@ -27,8 +27,7 @@ module Strings =
     let DetailPage_Toolbar_EditContact = "Edit"
     let EditPage_DeleteContact firstName lastName = $"Delete %s{firstName} %s{lastName}"
 
-    let EditPage_DeleteContactConfirmation =
-        "This action is definitive. Are you sure?"
+    let EditPage_DeleteContactConfirmation = "This action is definitive. Are you sure?"
 
     let EditPage_InvalidContactTitle = "Invalid contact"
     let EditPage_InvalidContactDescription = "Please fill all mandatory fields"

--- a/samples/FabulousContacts/iOS.Mono/AppDelegate.fs
+++ b/samples/FabulousContacts/iOS.Mono/AppDelegate.fs
@@ -16,11 +16,9 @@ type AppDelegate() =
     inherit FormsApplicationDelegate()
 
     let getDbPath () =
-        let docFolder =
-            Environment.GetFolderPath(Environment.SpecialFolder.Personal)
+        let docFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal)
 
-        let libFolder =
-            Path.Combine(docFolder, "..", "Library", "Databases")
+        let libFolder = Path.Combine(docFolder, "..", "Library", "Databases")
 
         if not(Directory.Exists libFolder) then
             Directory.CreateDirectory(libFolder) |> ignore
@@ -33,14 +31,11 @@ type AppDelegate() =
         Forms.Init()
         FormsMaps.Init()
 
-        CrossMedia.Current.Initialize()
-        |> Async.AwaitTask
-        |> ignore
+        CrossMedia.Current.Initialize() |> Async.AwaitTask |> ignore
 
         let dbPath = getDbPath()
 
-        let application =
-            Program.startApplicationWithArgs dbPath App.program
+        let application = Program.startApplicationWithArgs dbPath App.program
 
         this.LoadApplication(application)
         base.FinishedLaunching(app, options)

--- a/samples/FabulousContacts/iOS.Mono/BorderedEntryRenderer.fs
+++ b/samples/FabulousContacts/iOS.Mono/BorderedEntryRenderer.fs
@@ -7,8 +7,7 @@ open Xamarin.Forms.Platform.iOS
 type BorderedEntryRenderer() =
     inherit EntryRenderer()
 
-    member this.BorderedEntry =
-        this.Element :?> FabulousContacts.Controls.BorderedEntry
+    member this.BorderedEntry = this.Element :?> FabulousContacts.Controls.BorderedEntry
 
     override this.OnElementChanged(e) =
         base.OnElementChanged(e)
@@ -27,6 +26,5 @@ type BorderedEntryRenderer() =
             this.Control.Layer.CornerRadius <- nfloat 5.
 
 module Dummy_BorderedEntryRenderer =
-    [<assembly: Xamarin.Forms.ExportRenderer(typeof<FabulousContacts.Controls.BorderedEntry>,
-                                             typeof<BorderedEntryRenderer>)>]
+    [<assembly: Xamarin.Forms.ExportRenderer(typeof<FabulousContacts.Controls.BorderedEntry>, typeof<BorderedEntryRenderer>)>]
     do ()

--- a/samples/FabulousContacts/iOS.Mono/UnderlinedLabelRenderer.fs
+++ b/samples/FabulousContacts/iOS.Mono/UnderlinedLabelRenderer.fs
@@ -10,15 +10,12 @@ type UnderlinedLabelRenderer() =
         base.OnElementChanged(e)
 
         if (e.NewElement <> null) then
-            this.Control.AttributedText <-
-                new NSAttributedString(str = this.Element.Text, underlineStyle = NSUnderlineStyle.Single)
+            this.Control.AttributedText <- new NSAttributedString(str = this.Element.Text, underlineStyle = NSUnderlineStyle.Single)
 
     override this.OnElementPropertyChanged(_, e) =
         if e.PropertyName = "Text" then
-            this.Control.AttributedText <-
-                new NSAttributedString(str = this.Element.Text, underlineStyle = NSUnderlineStyle.Single)
+            this.Control.AttributedText <- new NSAttributedString(str = this.Element.Text, underlineStyle = NSUnderlineStyle.Single)
 
 module Dummy_UnderlinedLabelRenderer =
-    [<assembly: Xamarin.Forms.ExportRenderer(typeof<FabulousContacts.Controls.UnderlinedLabel>,
-                                             typeof<UnderlinedLabelRenderer>)>]
+    [<assembly: Xamarin.Forms.ExportRenderer(typeof<FabulousContacts.Controls.UnderlinedLabel>, typeof<UnderlinedLabelRenderer>)>]
     do ()

--- a/samples/FabulousWeather/Android.Mono/MainActivity.fs
+++ b/samples/FabulousWeather/Android.Mono/MainActivity.fs
@@ -14,8 +14,7 @@ open Xamarin.Forms.Platform.Android
            Icon = "@drawable/icon",
            Theme = "@style/MainTheme",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation))>]
+           ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -29,11 +28,6 @@ type MainActivity() =
 
         this.LoadApplication(Program.startApplication App.program)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/samples/FabulousWeather/FabulousWeather/App.fs
+++ b/samples/FabulousWeather/FabulousWeather/App.fs
@@ -37,15 +37,15 @@ module App =
     let initModel =
         { CurrentCityIndex = 0
           Cities =
-              [| { Name = "Seattle"
-                   Data = None
-                   IsRefreshing = true }
-                 { Name = "New York"
-                   Data = None
-                   IsRefreshing = true }
-                 { Name = "Paris"
-                   Data = None
-                   IsRefreshing = true } |] }
+            [| { Name = "Seattle"
+                 Data = None
+                 IsRefreshing = true }
+               { Name = "New York"
+                 Data = None
+                 IsRefreshing = true }
+               { Name = "Paris"
+                 Data = None
+                 IsRefreshing = true } |] }
 
     let init () =
         let cmd =
@@ -58,52 +58,38 @@ module App =
         | GoToPreviousCity ->
             let prevIndex = Math.Max(0, model.CurrentCityIndex - 1)
 
-            { model with
-                  CurrentCityIndex = prevIndex },
-            Cmd.none
+            { model with CurrentCityIndex = prevIndex }, Cmd.none
 
         | GoToNextCity ->
             let nextIndex = Math.Max(0, model.CurrentCityIndex + 1)
 
-            { model with
-                  CurrentCityIndex = nextIndex },
-            Cmd.none
+            { model with CurrentCityIndex = nextIndex }, Cmd.none
 
         | RequestRefresh index ->
             let updatedCities =
                 model.Cities
-                |> Array.mapi
-                    (fun i c ->
-                        if i = index then
-                            { c with IsRefreshing = true }
-                        else
-                            c)
+                |> Array.mapi(fun i c -> if i = index then { c with IsRefreshing = true } else c)
 
-            let cmd =
-                getWeatherForCityAsync index model.Cities.[index].Name
+            let cmd = getWeatherForCityAsync index model.Cities.[index].Name
 
             { model with Cities = updatedCities }, cmd
 
-        | WeatherRefreshed (index, data) ->
+        | WeatherRefreshed(index, data) ->
             let updatedCities =
                 model.Cities
-                |> Array.mapi
-                    (fun i c ->
-                        if i = index then
-                            { c with
-                                  IsRefreshing = false
-                                  Data = Some data }
-                        else
-                            c)
+                |> Array.mapi(fun i c ->
+                    if i = index then
+                        { c with
+                            IsRefreshing = false
+                            Data = Some data }
+                    else
+                        c)
 
             { model with Cities = updatedCities }, Cmd.none
 
     let previousNextView model =
         (Grid() {
-            cityView
-                model.CurrentCityIndex
-                model.Cities.[model.CurrentCityIndex]
-                (RequestRefresh model.CurrentCityIndex)
+            cityView model.CurrentCityIndex model.Cities.[model.CurrentCityIndex] (RequestRefresh model.CurrentCityIndex)
 
             if model.CurrentCityIndex > 0 then
                 Button($"< {model.Cities.[model.CurrentCityIndex - 1].Name}", GoToPreviousCity)
@@ -116,7 +102,7 @@ module App =
                     .alignEndHorizontal()
                     .alignStartVertical()
                     .margin(0., 0., 20., 0.)
-         })
+        })
             .padding(0., 35., 0., 0.)
 
     let view model =
@@ -126,10 +112,7 @@ module App =
             |> Option.defaultValue 0<kelvin>
 
         Application(
-            ContentPage(
-                "Weather",
-                PancakeView(Styles.gradientStops temperatureOfCurrentCity, ContentView(previousNextView model))
-            )
+            ContentPage("Weather", PancakeView(Styles.gradientStops temperatureOfCurrentCity, ContentView(previousNextView model)))
                 .ignoreSafeArea()
         )
     //.resources([

--- a/samples/FabulousWeather/FabulousWeather/CityView.fs
+++ b/samples/FabulousWeather/FabulousWeather/CityView.fs
@@ -27,9 +27,7 @@ module CityView =
                 .centerTextHorizontal()
                 .padding(0., 20., 0., 0.)
 
-            ActivityIndicator(true)
-                .centerHorizontal()
-                .centerVertical(expand = true)
+            ActivityIndicator(true).centerHorizontal().centerVertical(expand = true)
         }
 
     let loadedView (index, cityName: string, isRefreshing, data) onRefreshing =
@@ -40,12 +38,9 @@ module CityView =
             onRefreshing,
             ScrollView(
                 VStack() {
-                    Label(cityName.ToUpper())
-                        .font(Styles.CityNameFontSize)
-                        .centerTextHorizontal()
+                    Label(cityName.ToUpper()).font(Styles.CityNameFontSize).centerTextHorizontal()
 
-                    Image(Aspect.AspectFit, $"{sanitizedCityName}.png")
-                        .opacity(0.8)
+                    Image(Aspect.AspectFit, $"{sanitizedCityName}.png").opacity(0.8)
 
                     Label($"{Helpers.kelvinToRoundedFahrenheit data.Temperature}°")
                         .font(Styles.CurrentTemperatureFontSize)
@@ -57,12 +52,7 @@ module CityView =
                         .centerTextHorizontal()
                         .margin(Thickness(0., 10., 0., 0.))
 
-                    Label(
-                        data
-                            .Date
-                            .ToString("dddd, MMMM dd, yyyy, h:mm tt")
-                            .ToUpper()
-                    )
+                    Label(data.Date.ToString("dddd, MMMM dd, yyyy, h:mm tt").ToUpper())
                         .font(Styles.CurrentDateFontSize)
                         .centerTextHorizontal()
 
@@ -72,13 +62,9 @@ module CityView =
                                 PancakeView(
                                     Styles.HourlyForecastGradientStops,
                                     VStack() {
-                                        Label(forecast.Date.ToString("h tt").ToLower())
-                                            .centerTextHorizontal()
+                                        Label(forecast.Date.ToString("h tt").ToLower()).centerTextHorizontal()
 
-                                        Image(
-                                            Aspect.AspectFit,
-                                            Uri($"http://openweathermap.org/img/wn/{forecast.IconName}@2x.png")
-                                        )
+                                        Image(Aspect.AspectFit, Uri($"http://openweathermap.org/img/wn/{forecast.IconName}@2x.png"))
                                             .centerHorizontal()
                                             .centerVertical(expand = true)
 
@@ -88,7 +74,7 @@ module CityView =
                                 )
                             )
                                 .background(Styles.HourlyForecastStartColor)
-                     })
+                    })
                         .centerHorizontal()
                         .margin(0., 30., 0., 0.)
                 }
@@ -104,8 +90,6 @@ module CityView =
 
         match city.Data with
         | Some data ->
-            ContentView(loadedView(index, city.Name, city.IsRefreshing, data) onRefreshing)
+            ContentView(loadedView (index, city.Name, city.IsRefreshing, data) onRefreshing)
                 .padding(padding)
-        | None ->
-            ContentView(loadingView city.Name)
-                .padding(padding)
+        | None -> ContentView(loadingView city.Name).padding(padding)

--- a/samples/FabulousWeather/FabulousWeather/Helpers.fs
+++ b/samples/FabulousWeather/FabulousWeather/Helpers.fs
@@ -10,14 +10,12 @@ type fahrenheit
 
 module Helpers =
     let kelvinToRoundedFahrenheit K =
-        let realValue =
-            (9. / 5. * (float(K - 273<kelvin>)) + 32.)
+        let realValue = (9. / 5. * (float(K - 273<kelvin>)) + 32.)
 
         let roundedValue = Math.Round realValue |> int
         roundedValue * 1<fahrenheit>
 
     let unixTimestampToDateTime (timestamp: int) =
-        let epoch =
-            DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+        let epoch = DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)
 
         epoch.AddSeconds(float timestamp).ToLocalTime()

--- a/samples/FabulousWeather/FabulousWeather/PancakeView.fs
+++ b/samples/FabulousWeather/FabulousWeather/PancakeView.fs
@@ -9,8 +9,7 @@ type IPancakeView =
     inherit IView
 
 module PancakeView =
-    let WidgetKey =
-        Widgets.register<Xamarin.Forms.PancakeView.PancakeView>()
+    let WidgetKey = Widgets.register<Xamarin.Forms.PancakeView.PancakeView>()
 
     let BackgroundGradientStops =
         Attributes.defineBindableWithEquality<Xamarin.Forms.PancakeView.GradientStopCollection>
@@ -22,11 +21,8 @@ module PancakeView =
 [<AutoOpen>]
 module PancakeViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline PancakeView<'msg, 'marker when 'marker :> IView>
-            (
-                backgroundGradientStops,
-                content: WidgetBuilder<'msg, 'marker>
-            ) =
+
+        static member inline PancakeView<'msg, 'marker when 'marker :> IView>(backgroundGradientStops, content: WidgetBuilder<'msg, 'marker>) =
             WidgetBuilder<'msg, IPancakeView>(
                 PancakeView.WidgetKey,
                 AttributesBundle(

--- a/samples/FabulousWeather/FabulousWeather/Styles.fs
+++ b/samples/FabulousWeather/FabulousWeather/Styles.fs
@@ -34,36 +34,29 @@ module Styles =
 
     let registerGlobalResources (app: Application) =
         app
-        |> addStyles [ createStyleFor<Label> [ Label.TextColorProperty, box AccentTextColor ]
-                       createStyleFor<Button> [ Button.TextColorProperty, box AccentTextColor ] ]
+        |> addStyles
+            [ createStyleFor<Label> [ Label.TextColorProperty, box AccentTextColor ]
+              createStyleFor<Button> [ Button.TextColorProperty, box AccentTextColor ] ]
 
     let getStartGradientColor temp =
-        if temp > 288<kelvin> then
-            WarmStartColor
-        else if temp < 199<kelvin> then
-            NightStartColor
-        else
-            ColdStartColor
+        if temp > 288<kelvin> then WarmStartColor
+        else if temp < 199<kelvin> then NightStartColor
+        else ColdStartColor
 
     let getEndGradientColor temp =
-        if temp > 288<kelvin> then
-            WarmEndColor
-        else if temp < 199<kelvin> then
-            NightEndColor
-        else
-            ColdEndColor
+        if temp > 288<kelvin> then WarmEndColor
+        else if temp < 199<kelvin> then NightEndColor
+        else ColdEndColor
 
     let gradientStops temp =
-        let coll =
-            Xamarin.Forms.PancakeView.GradientStopCollection()
+        let coll = Xamarin.Forms.PancakeView.GradientStopCollection()
 
         coll.Add(PancakeView.GradientStop(Color = (getStartGradientColor temp).ToXFColor(), Offset = float32 0.))
         coll.Add(PancakeView.GradientStop(Color = (getEndGradientColor temp).ToXFColor(), Offset = float32 1.))
         coll
 
     let HourlyForecastGradientStops =
-        let coll =
-            Xamarin.Forms.PancakeView.GradientStopCollection()
+        let coll = Xamarin.Forms.PancakeView.GradientStopCollection()
 
         coll.Add(PancakeView.GradientStop(Color = HourlyForecastStartColor.ToXFColor(), Offset = float32 0.))
         coll.Add(PancakeView.GradientStop(Color = HourlyForecastEndColor.ToXFColor(), Offset = float32 1.))

--- a/samples/FabulousWeather/FabulousWeather/WeatherApi.fs
+++ b/samples/FabulousWeather/FabulousWeather/WeatherApi.fs
@@ -9,11 +9,9 @@ module WeatherApi =
 
     let baseEndpoint = "http://api.openweathermap.org/data/2.5"
 
-    let currentWeatherEndpoint =
-        $"%s{baseEndpoint}/weather?appid=%s{apiKey}"
+    let currentWeatherEndpoint = $"%s{baseEndpoint}/weather?appid=%s{apiKey}"
 
-    let hourlyForecastEndpoint =
-        $"%s{baseEndpoint}/forecast?appid=%s{apiKey}"
+    let hourlyForecastEndpoint = $"%s{baseEndpoint}/forecast?appid=%s{apiKey}"
 
     type CurrentWeatherApi = JsonProvider<"WeatherSamples/current-weather.json">
     type HourlyForecastApi = JsonProvider<"WeatherSamples/hourly-forecast.json">
@@ -74,12 +72,8 @@ module WeatherApi =
             let! currentWeather = CurrentWeatherApi.AsyncLoad $"%s{currentWeatherEndpoint}&q=%s{name}"
 
             return
-                { Date =
-                      currentWeather.Dt
-                      |> Helpers.unixTimestampToDateTime
-                  WeatherKind =
-                      currentWeather.Weather.[0].Main
-                      |> WeatherKind.Parse
+                { Date = currentWeather.Dt |> Helpers.unixTimestampToDateTime
+                  WeatherKind = currentWeather.Weather.[0].Main |> WeatherKind.Parse
                   Temperature = (int currentWeather.Main.Temp) * 1<kelvin> }
         }
 
@@ -89,13 +83,12 @@ module WeatherApi =
 
             return
                 { Values =
-                      hourlyForecast.List
-                      |> Array.toList
-                      |> List.take 5
-                      |> List.map
-                          (fun v ->
-                              { Date = v.Dt |> Helpers.unixTimestampToDateTime
-                                Temperature = (int v.Main.Temp) * 1<kelvin>
-                                WeatherKind = v.Weather.[0].Main |> WeatherKind.Parse
-                                IconName = v.Weather.[0].Icon }) }
+                    hourlyForecast.List
+                    |> Array.toList
+                    |> List.take 5
+                    |> List.map(fun v ->
+                        { Date = v.Dt |> Helpers.unixTimestampToDateTime
+                          Temperature = (int v.Main.Temp) * 1<kelvin>
+                          WeatherKind = v.Weather.[0].Main |> WeatherKind.Parse
+                          IconName = v.Weather.[0].Icon }) }
         }

--- a/samples/TicTacToe/Android.Mono/MainActivity.fs
+++ b/samples/TicTacToe/Android.Mono/MainActivity.fs
@@ -14,8 +14,7 @@ open Xamarin.Forms.Platform.Android
            Icon = "@drawable/icon",
            Theme = "@style/MainTheme",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation))>]
+           ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -29,11 +28,6 @@ type MainActivity() =
 
         this.LoadApplication(Program.startApplication App.program)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/samples/TicTacToe/TicTacToe/App.fs
+++ b/samples/TicTacToe/TicTacToe/App.fs
@@ -10,6 +10,7 @@ open type Fabulous.XamarinForms.View
 type Player =
     | X
     | O
+
     member p.Swap =
         match p with
         | X -> O
@@ -24,6 +25,7 @@ type Player =
 type GameCell =
     | Empty
     | Full of Player
+
     member x.CanPlay = (x = Empty)
 
 /// Represents the result of a game
@@ -50,30 +52,30 @@ type Row = GameCell list
 /// Represents the state of the game
 type Model =
     {
-      /// Who is next to play
-      NextUp: Player
+        /// Who is next to play
+        NextUp: Player
 
-      /// The state of play on the board
-      Board: Board
+        /// The state of play on the board
+        Board: Board
 
-      /// The state of play on the board
-      GameScore: int * int
+        /// The state of play on the board
+        GameScore: int * int
 
-      /// The model occasionally includes things related to the view.  In this case,
-      /// we track the desired visual size of the board, to ensure a square, in response to
-      /// updates telling us the overall allocated size.
-      VisualBoardSize: double option }
+        /// The model occasionally includes things related to the view.  In this case,
+        /// we track the desired visual size of the board, to ensure a square, in response to
+        /// updates telling us the overall allocated size.
+        VisualBoardSize: double option
+    }
 
 /// The model, update and view content of the app. This is placed in an
 /// independent model to facilitate unit testing.
 module App =
     let positions =
-        [ for x in 0 .. 2 do
-              for y in 0 .. 2 do
+        [ for x in 0..2 do
+              for y in 0..2 do
                   yield (x, y) ]
 
-    let initialBoard =
-        Map.ofList [ for p in positions -> p, Empty ]
+    let initialBoard = Map.ofList [ for p in positions -> p, Empty ]
 
     let init () =
         { NextUp = X
@@ -88,10 +90,10 @@ module App =
     let lines =
         [
           // rows
-          for row in 0 .. 2 do
+          for row in 0..2 do
               yield [ (row, 0); (row, 1); (row, 2) ]
           // columns
-          for col in 0 .. 2 do
+          for col in 0..2 do
               yield [ (0, col); (1, col); (2, col) ]
           // diagonals
           yield [ (0, 0); (1, 1); (2, 2) ]
@@ -102,33 +104,28 @@ module App =
 
     /// Determine if a line is a winning line.
     let getLineWinner line =
-        if line
-           |> List.forall
-               (function
-               | Full X -> true
-               | _ -> false) then
+        if
+            line
+            |> List.forall (function
+                | Full X -> true
+                | _ -> false)
+        then
             Some X
-        elif line
-             |> List.forall
-                 (function
-                 | Full O -> true
-                 | _ -> false) then
+        elif
+            line
+            |> List.forall (function
+                | Full O -> true
+                | _ -> false)
+        then
             Some O
         else
             None
 
     /// Determine the game result, if any.
     let getGameResult model =
-        match
-            lines
-            |> Seq.tryPick(getLine model.Board >> getLineWinner)
-            with
+        match lines |> Seq.tryPick(getLine model.Board >> getLineWinner) with
         | Some p -> Win p
-        | _ ->
-            if anyMoreMoves model then
-                StillPlaying
-            else
-                Draw
+        | _ -> if anyMoreMoves model then StillPlaying else Draw
 
     /// Get a message to show the current game result
     let getMessage model =
@@ -143,8 +140,8 @@ module App =
         | Play pos ->
             let newModel =
                 { model with
-                      Board = model.Board.Add(pos, Full model.NextUp)
-                      NextUp = model.NextUp.Swap }
+                    Board = model.Board.Add(pos, Full model.NextUp)
+                    NextUp = model.NextUp.Swap }
 
             // Make an announcement in the middle of the game.
             let result = getGameResult newModel
@@ -156,23 +153,20 @@ module App =
                 let x, y = newModel.GameScore
 
                 match result with
-                | Win p ->
-                    { newModel with
-                          GameScore = (if p = X then (x + 1, y) else (x, y + 1)) }
+                | Win p -> { newModel with GameScore = (if p = X then (x + 1, y) else (x, y + 1)) }
                 | _ -> newModel
 
             // Return the new model.
             newModel2
         | Restart ->
             { model with
-                  NextUp = X
-                  Board = initialBoard
-                  GameScore = (0, 0) }
+                NextUp = X
+                Board = initialBoard
+                GameScore = (0, 0) }
         | VisualBoardSizeChanged args ->
             let size = min args.Width args.Height - 80.
 
-            { model with
-                  VisualBoardSize = Some size }
+            { model with VisualBoardSize = Some size }
 
     /// A helper used in the 'view' function to get the name
     /// of the Xaml resource for the image for a player
@@ -194,8 +188,7 @@ module App =
     /// A condition used in the 'view' function to check if we can play in a cell.
     /// The visual contents of a cell depends on this condition.
     let canPlay model cell =
-        (cell = Empty)
-        && (getGameResult model = StillPlaying)
+        (cell = Empty) && (getGameResult model = StillPlaying)
 
     module private Colors =
         let black = Color.Black.ToFabColor()
@@ -209,16 +202,7 @@ module App =
                     ContentPage(
                         "TicTacToe",
                         Grid(coldefs = [ Star ], rowdefs = [ Star; Auto; Auto ]) {
-                            (Grid(coldefs = [ Star
-                                              Absolute 5.0
-                                              Star
-                                              Absolute 5.0
-                                              Star ],
-                                  rowdefs = [ Star
-                                              Absolute 5.0
-                                              Star
-                                              Absolute 5.0
-                                              Star ]) {
+                            (Grid(coldefs = [ Star; Absolute 5.0; Star; Absolute 5.0; Star ], rowdefs = [ Star; Absolute 5.0; Star; Absolute 5.0; Star ]) {
                                 BoxView(Colors.black).gridRow(1).gridColumnSpan(5)
                                 BoxView(Colors.black).gridRow(3).gridColumnSpan(5)
                                 BoxView(Colors.black).gridColumn(1).gridRowSpan(5)
@@ -236,7 +220,7 @@ module App =
                                             .margin(10.)
                                             .gridRow(row * 2)
                                             .gridColumn(col * 2)
-                             })
+                            })
                                 .rowSpacing(0.)
                                 .columnSpacing(0.)
                                 .center()
@@ -261,7 +245,7 @@ module App =
                 match model.VisualBoardSize with
                 | None -> contentPage.onSizeAllocated(VisualBoardSizeChanged)
                 | Some _ -> contentPage
-             })
+            })
                 .barBackgroundColor(Colors.lightBlue)
                 .barTextColor(Colors.black)
         )
@@ -271,10 +255,6 @@ module App =
     // this dependency out to allow unit testing of the 'update' function.
 
     let gameOver msg =
-        Application.Current.Dispatcher.BeginInvokeOnMainThread
-            (fun () ->
-                Application.Current.MainPage.DisplayAlert("Game over", msg, "OK")
-                |> ignore)
+        Application.Current.Dispatcher.BeginInvokeOnMainThread(fun () -> Application.Current.MainPage.DisplayAlert("Game over", msg, "OK") |> ignore)
 
-    let program =
-        Program.stateful init (update gameOver) view
+    let program = Program.stateful init (update gameOver) view

--- a/src/Fabulous.XamarinForms.Tests/AttributesTests.fs
+++ b/src/Fabulous.XamarinForms.Tests/AttributesTests.fs
@@ -12,8 +12,7 @@ type ``Small scalar encode tests``() =
     member _.``Encoding then decoding a LayoutOptions should return an identical LayoutOptions``(value: LayoutOptions) =
         let encoded = SmallScalars.LayoutOptions.encode value
 
-        let decoded =
-            SmallScalars.LayoutOptions.decode encoded
+        let decoded = SmallScalars.LayoutOptions.decode encoded
 
         Assert.AreEqual(value.Alignment, decoded.Alignment)
         Assert.AreEqual(value.Expands, decoded.Expands)
@@ -39,11 +38,7 @@ type ``Small scalar encode tests``() =
             let expectedU8 = uint8(expected * 255.0)
             let actualU8 = uint8(actual * 255.0)
 
-            let lowerBound =
-                if expectedU8 = 0uy then
-                    0uy
-                else
-                    expectedU8 - 1uy
+            let lowerBound = if expectedU8 = 0uy then 0uy else expectedU8 - 1uy
 
             Assert.GreaterOrEqual(actualU8, lowerBound)
             Assert.LessOrEqual(actualU8, expectedU8)

--- a/src/Fabulous.XamarinForms.Tests/Generators.fs
+++ b/src/Fabulous.XamarinForms.Tests/Generators.fs
@@ -9,10 +9,11 @@ module SmallScalarGenerators =
     let layoutOptionsGenerator =
         gen {
             let! layoutAlignment =
-                Gen.elements [ LayoutAlignment.Start
-                               LayoutAlignment.Center
-                               LayoutAlignment.End
-                               LayoutAlignment.Fill ]
+                Gen.elements
+                    [ LayoutAlignment.Start
+                      LayoutAlignment.Center
+                      LayoutAlignment.End
+                      LayoutAlignment.Fill ]
 
             let! expands = Arb.generate<bool>
             return LayoutOptions(layoutAlignment, expands)
@@ -20,9 +21,7 @@ module SmallScalarGenerators =
 
     let fabcolorGenerator =
         gen {
-            let fabcolorGen =
-                Arb.generate<uint8>
-                |> Gen.where(fun x -> x >= 0uy && x <= 255uy)
+            let fabcolorGen = Arb.generate<uint8> |> Gen.where(fun x -> x >= 0uy && x <= 255uy)
 
             let! red = fabcolorGen
             let! green = fabcolorGen
@@ -33,9 +32,7 @@ module SmallScalarGenerators =
 
     let colorGenerator =
         gen {
-            let colorGen =
-                Arb.generate<float>
-                |> Gen.where(fun x -> x >= 0.0 && x <= 1.0)
+            let colorGen = Arb.generate<float> |> Gen.where(fun x -> x >= 0.0 && x <= 1.0)
 
             let! red = colorGen
             let! green = colorGen
@@ -47,8 +44,7 @@ module SmallScalarGenerators =
 type Generators =
     static member LayoutOptions() =
         { new Arbitrary<LayoutOptions>() with
-            member this.Generator =
-                SmallScalarGenerators.layoutOptionsGenerator }
+            member this.Generator = SmallScalarGenerators.layoutOptionsGenerator }
 
     static member Color() =
         { new Arbitrary<Color>() with

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -14,9 +14,9 @@ module AppTheme =
     let inline create<'T when 'T: equality> (light: 'T) (dark: 'T option) =
         { Light = light
           Dark =
-              match dark with
-              | None -> light
-              | Some v -> v }
+            match dark with
+            | None -> light
+            | Some v -> v }
 
 [<Struct>]
 type ValueEventData<'data, 'eventArgs> =
@@ -38,17 +38,12 @@ module SmallScalars =
         let inline encode (v: AppThemeValues<FabColor>) : uint64 =
             let { Light = light; Dark = dark } = v
 
-            ((FabColor.encode light) <<< 32)
-            ||| (FabColor.encode dark)
+            ((FabColor.encode light) <<< 32) ||| (FabColor.encode dark)
 
         let inline decode (encoded: uint64) : AppThemeValues<FabColor> =
-            let light =
-                ((encoded &&& 0xFFFFFFFF00000000UL) >>> 32)
-                |> FabColor.decode
+            let light = ((encoded &&& 0xFFFFFFFF00000000UL) >>> 32) |> FabColor.decode
 
-            let dark =
-                (encoded &&& 0x00000000FFFFFFFFUL)
-                |> FabColor.decode
+            let dark = (encoded &&& 0x00000000FFFFFFFFUL) |> FabColor.decode
 
             { Light = light; Dark = dark }
 
@@ -90,39 +85,30 @@ module Attributes =
         ([<InlineIfLambda>] convertValue: 'modelType -> 'valueType)
         ([<InlineIfLambda>] compare: 'modelType -> 'modelType -> ScalarAttributeComparison)
         =
-        Attributes.defineScalar<'modelType, 'valueType>
-            bindableProperty.PropertyName
-            convertValue
-            compare
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineScalar<'modelType, 'valueType> bindableProperty.PropertyName convertValue compare (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome v -> target.SetValue(bindableProperty, v))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v -> target.SetValue(bindableProperty, v))
 
     /// Define an attribute for a BindableProperty supporting equality comparison
     let inline defineBindableWithEquality<'T when 'T: equality> (bindableProperty: BindableProperty) =
-        Attributes.defineSimpleScalarWithEquality<'T>
-            bindableProperty.PropertyName
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<'T> bindableProperty.PropertyName (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome v -> target.SetValue(bindableProperty, v))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v -> target.SetValue(bindableProperty, v))
 
     /// Define an attribute that can fit into 8 bytes encoded as uint64 (such as float or bool) for a BindableProperty
     let inline defineSmallBindable<'T> (bindableProperty: BindableProperty) ([<InlineIfLambda>] decode: uint64 -> 'T) =
-        Attributes.defineSmallScalar<'T>
-            bindableProperty.PropertyName
-            decode
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSmallScalar<'T> bindableProperty.PropertyName decode (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome v -> target.SetValue(bindableProperty, v))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v -> target.SetValue(bindableProperty, v))
 
     /// Define a float attribute for a BindableProperty and encode it as a small scalar (8 bytes)
     let inline defineBindableFloat (bindableProperty: BindableProperty) =
@@ -142,67 +128,51 @@ module Attributes =
     /// Note if you want to use Xamarin.Forms.Color directly you can do that with "defineBindable".
     /// However, XF.Color will be boxed and thus slower.
     let inline defineBindableColor (bindableProperty: BindableProperty) : SmallScalarAttributeDefinition<FabColor> =
-        Attributes.defineSmallScalar<FabColor>
-            bindableProperty.PropertyName
-            SmallScalars.FabColor.decode
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSmallScalar<FabColor> bindableProperty.PropertyName SmallScalars.FabColor.decode (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome v -> target.SetValue(bindableProperty, v.ToXFColor()))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v -> target.SetValue(bindableProperty, v.ToXFColor()))
 
     /// Define an enum attribute for a BindableProperty and encode it as a small scalar (8 bytes)
-    let inline defineBindableEnum< ^T when ^T: enum<int>>
-        (bindableProperty: BindableProperty)
-        : SmallScalarAttributeDefinition< ^T > =
-        Attributes.defineEnum< ^T>
-            bindableProperty.PropertyName
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+    let inline defineBindableEnum< ^T when ^T: enum<int>> (bindableProperty: BindableProperty) : SmallScalarAttributeDefinition< ^T > =
+        Attributes.defineEnum< ^T> bindableProperty.PropertyName (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome v -> target.SetValue(bindableProperty, v))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v -> target.SetValue(bindableProperty, v))
 
     /// Define an attribute that supports values for both Light and Dark themes
     let inline defineBindableAppTheme<'T when 'T: equality> (bindableProperty: BindableProperty) =
-        Attributes.defineSimpleScalarWithEquality<AppThemeValues<'T>>
-            bindableProperty.PropertyName
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<AppThemeValues<'T>> bindableProperty.PropertyName (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
-                | ValueSome { Light = light; Dark = dark } when dark = light -> target.SetValue(bindableProperty, light)
-                | ValueSome { Light = light; Dark = dark } -> target.SetOnAppTheme(bindableProperty, light, dark))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome { Light = light; Dark = dark } when dark = light -> target.SetValue(bindableProperty, light)
+            | ValueSome { Light = light; Dark = dark } -> target.SetOnAppTheme(bindableProperty, light, dark))
 
     /// Define a Color attribute that supports values for both Light and Dark themes
     /// Note that we use FabColor here because we can encode two into 8 bytes
     /// Thus we can avoid heap allocations
     let inline defineBindableAppThemeColor (bindableProperty: BindableProperty) =
-        Attributes.defineSmallScalar<AppThemeValues<FabColor>>
-            bindableProperty.PropertyName
-            SmallScalars.ThemedColor.decode
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSmallScalar<AppThemeValues<FabColor>> bindableProperty.PropertyName SmallScalars.ThemedColor.decode (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(bindableProperty)
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
 
-                | ValueSome { Light = light; Dark = dark } when light = dark ->
-                    target.SetValue(bindableProperty, light.ToXFColor())
+            | ValueSome { Light = light; Dark = dark } when light = dark -> target.SetValue(bindableProperty, light.ToXFColor())
 
-                | ValueSome { Light = light; Dark = dark } ->
-                    target.SetOnAppTheme(bindableProperty, light.ToXFColor(), dark.ToXFColor()))
+            | ValueSome { Light = light; Dark = dark } -> target.SetOnAppTheme(bindableProperty, light.ToXFColor(), dark.ToXFColor()))
 
     /// Define an attribute storing a Widget for a bindable property
     let inline defineBindableWidget (bindableProperty: BindableProperty) =
         Attributes.definePropertyWidget
             bindableProperty.PropertyName
-            (fun target ->
-                (target :?> BindableObject)
-                    .GetValue(bindableProperty))
+            (fun target -> (target :?> BindableObject).GetValue(bindableProperty))
             (fun target value ->
                 let bindableObject = target :?> BindableObject
 
@@ -250,10 +220,9 @@ module Attributes =
 
                         // Set the new event handler
                         let handler =
-                            EventHandler<'args>
-                                (fun _ args ->
-                                    let r = curr.Event args
-                                    Dispatcher.dispatch node r)
+                            EventHandler<'args>(fun _ args ->
+                                let r = curr.Event args
+                                Dispatcher.dispatch node r)
 
                         node.SetHandler(name, ValueSome handler)
                         event.AddHandler(handler))

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -47,8 +47,7 @@ type FabulousContentPage() as this =
     inherit ContentPage()
     do Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(this, true)
 
-    let sizeAllocated =
-        Event<EventHandler<SizeAllocatedEventArgs>, _>()
+    let sizeAllocated = Event<EventHandler<SizeAllocatedEventArgs>, _>()
 
     [<CLIEvent>]
     member __.SizeAllocated = sizeAllocated.Publish
@@ -70,8 +69,7 @@ type PositionChangedEventArgs(previousPosition: int, currentPosition: int) =
 type FabulousTimePicker() =
     inherit TimePicker()
 
-    let timeSelected =
-        Event<EventHandler<TimeSelectedEventArgs>, _>()
+    let timeSelected = Event<EventHandler<TimeSelectedEventArgs>, _>()
 
     [<CLIEvent>]
     member _.TimeSelected = timeSelected.Publish
@@ -92,8 +90,7 @@ type CustomEntryCell() =
 
     let mutable oldText = ""
 
-    let textChanged =
-        Event<EventHandler<TextChangedEventArgs>, _>()
+    let textChanged = Event<EventHandler<TextChangedEventArgs>, _>()
 
     [<CLIEvent>]
     member _.TextChanged = textChanged.Publish
@@ -116,8 +113,7 @@ type CustomPicker() =
 
     let mutable oldSelectedIndex = -1
 
-    let selectedIndexChanged =
-        Event<EventHandler<PositionChangedEventArgs>, _>()
+    let selectedIndexChanged = Event<EventHandler<PositionChangedEventArgs>, _>()
 
     [<CLIEvent>]
     member _.CustomSelectedIndexChanged = selectedIndexChanged.Publish

--- a/src/Fabulous.XamarinForms/FabColor.fs
+++ b/src/Fabulous.XamarinForms/FabColor.fs
@@ -11,6 +11,7 @@ open Xamarin.Forms
 [<Struct>]
 type FabColor =
     { RGBA: uint32 }
+
     member inline x.R: uint8 = (x.RGBA &&& 0xFF000000u) >>> 24 |> uint8
 
     member inline x.G: uint8 = (x.RGBA &&& 0x00FF0000u) >>> 16 |> uint8
@@ -43,8 +44,4 @@ module FabColor =
 
     /// Creates a FabColor from 4 byte size components. Expects RGBA ordering.
     let inline fromRGBA (r: uint8) (g: uint8) (b: uint8) (a: uint8) : FabColor =
-        { RGBA =
-              ((uint32 r <<< 24)
-               ||| (uint32 g <<< 16)
-               ||| (uint32 b <<< 8)
-               ||| uint32 a) }
+        { RGBA = ((uint32 r <<< 24) ||| (uint32 g <<< 16) ||| (uint32 b <<< 8) ||| uint32 a) }

--- a/src/Fabulous.XamarinForms/Program.fs
+++ b/src/Fabulous.XamarinForms/Program.fs
@@ -12,7 +12,7 @@ module ViewHelpers =
         match widget.ScalarAttributes with
         | ValueNone -> ValueNone
         | ValueSome scalarAttrs ->
-            match Array.tryFind(fun (attr: ScalarAttribute) -> attr.Key = def.Key) scalarAttrs with
+            match Array.tryFind (fun (attr: ScalarAttribute) -> attr.Key = def.Key) scalarAttrs with
             | None -> ValueNone
             | Some attr -> ValueSome(unbox<'data> attr.Value)
 
@@ -20,14 +20,13 @@ module ViewHelpers =
         match widget.WidgetCollectionAttributes with
         | ValueNone -> ValueNone
         | ValueSome collectionAttrs ->
-            match Array.tryFind(fun (attr: WidgetCollectionAttribute) -> attr.Key = def.Key) collectionAttrs with
+            match Array.tryFind (fun (attr: WidgetCollectionAttribute) -> attr.Key = def.Key) collectionAttrs with
             | None -> ValueNone
             | Some attr -> ValueSome attr.Value
 
     /// Extend the canReuseView function to check Xamarin.Forms specific constraints
     let rec canReuseView (prev: Widget) (curr: Widget) =
-        if ViewHelpers.canReuseView prev curr
-           && canReuseAutomationId prev curr then
+        if ViewHelpers.canReuseView prev curr && canReuseAutomationId prev curr then
             let def = WidgetDefinitionStore.get curr.Key
 
             // TargetType can be null for MemoWidget
@@ -45,11 +44,9 @@ module ViewHelpers =
     /// Check whether widgets have compatible automation ids.
     /// Xamarin.Forms only allows setting the automation id once so we can't reuse a control if the id is not the same.
     and private canReuseAutomationId (prev: Widget) (curr: Widget) =
-        let prevIdOpt =
-            tryGetScalarValue prev Element.AutomationId
+        let prevIdOpt = tryGetScalarValue prev Element.AutomationId
 
-        let currIdOpt =
-            tryGetScalarValue curr Element.AutomationId
+        let currIdOpt = tryGetScalarValue curr Element.AutomationId
 
         match prevIdOpt with
         | ValueSome _ when prevIdOpt <> currIdOpt -> false
@@ -60,11 +57,9 @@ module ViewHelpers =
     // NavigationPage can be reused only if the pages don't change their type (added/removed pages don't prevent reuse)
     // E.g. If the first page switch from ContentPage to TabbedPage, the NavigationPage can't be reused.
     and private canReuseNavigationPage (prev: Widget) (curr: Widget) =
-        let prevPages =
-            tryGetWidgetCollectionValue prev NavigationPage.Pages
+        let prevPages = tryGetWidgetCollectionValue prev NavigationPage.Pages
 
-        let currPages =
-            tryGetWidgetCollectionValue curr NavigationPage.Pages
+        let currPages = tryGetWidgetCollectionValue curr NavigationPage.Pages
 
         match struct (prevPages, currPages) with
         | ValueSome prevPages, ValueSome currPages ->
@@ -98,11 +93,7 @@ module ViewHelpers =
         false
 
 module Program =
-    let inline private define
-        (init: 'arg -> 'model * Cmd<'msg>)
-        (update: 'msg -> 'model -> 'model * Cmd<'msg>)
-        (view: 'model -> WidgetBuilder<'msg, 'marker>)
-        =
+    let inline private define (init: 'arg -> 'model * Cmd<'msg>) (update: 'msg -> 'model -> 'model * Cmd<'msg>) (view: 'model -> WidgetBuilder<'msg, 'marker>) =
         { Init = init
           Update = (fun (msg, model) -> update msg model)
           Subscribe = fun _ -> Cmd.none
@@ -114,22 +105,14 @@ module Program =
 
     /// Create a program for a static view
     let stateless (view: unit -> WidgetBuilder<unit, 'marker>) =
-        define(fun () -> (), Cmd.none) (fun () () -> (), Cmd.none) view
+        define (fun () -> (), Cmd.none) (fun () () -> (), Cmd.none) view
 
     /// Create a program using an MVU loop
-    let stateful
-        (init: 'arg -> 'model)
-        (update: 'msg -> 'model -> 'model)
-        (view: 'model -> WidgetBuilder<'msg, 'marker>)
-        =
-        define(fun arg -> init arg, Cmd.none) (fun msg model -> update msg model, Cmd.none) view
+    let stateful (init: 'arg -> 'model) (update: 'msg -> 'model -> 'model) (view: 'model -> WidgetBuilder<'msg, 'marker>) =
+        define (fun arg -> init arg, Cmd.none) (fun msg model -> update msg model, Cmd.none) view
 
     /// Create a program using an MVU loop. Add support for Cmd
-    let statefulWithCmd
-        (init: 'arg -> 'model * Cmd<'msg>)
-        (update: 'msg -> 'model -> 'model * Cmd<'msg>)
-        (view: 'model -> WidgetBuilder<'msg, #IApplication>)
-        =
+    let statefulWithCmd (init: 'arg -> 'model * Cmd<'msg>) (update: 'msg -> 'model -> 'model * Cmd<'msg>) (view: 'model -> WidgetBuilder<'msg, #IApplication>) =
         define init update view
 
     /// Create a program using an MVU loop. Add support for CmdMsg
@@ -141,10 +124,7 @@ module Program =
         =
         let mapCmds cmdMsgs = cmdMsgs |> List.map mapCmd |> Cmd.batch
 
-        define
-            (fun arg -> let m, c = init arg in m, mapCmds c)
-            (fun msg model -> let m, c = update msg model in m, mapCmds c)
-            view
+        define (fun arg -> let m, c = init arg in m, mapCmds c) (fun msg model -> let m, c = update msg model in m, mapCmds c) view
 
     /// Start the program
     let startApplicationWithArgs (arg: 'arg) (program: Program<'arg, 'model, 'msg, #IApplication>) : Application =
@@ -154,15 +134,13 @@ module Program =
         adapter.CreateView() |> unbox
 
     /// Start the program
-    let startApplication (program: Program<unit, 'model, 'msg, 'marker>) : Application =
-        startApplicationWithArgs() program
+    let startApplication (program: Program<unit, 'model, 'msg, 'marker>) : Application = startApplicationWithArgs () program
 
     /// Subscribe to external source of events.
     /// The subscription is called once - with the initial model, but can dispatch new messages at any time.
     let withSubscription (subscribe: 'model -> Cmd<'msg>) (program: Program<'arg, 'model, 'msg, 'marker>) =
         let sub model =
-            Cmd.batch [ program.Subscribe model
-                        subscribe model ]
+            Cmd.batch [ program.Subscribe model; subscribe model ]
 
         { program with Subscribe = sub }
 
@@ -176,8 +154,7 @@ module Program =
                 let initModel, cmd = program.Init(arg)
                 trace("Initial model: {0}", $"%0A{initModel}")
                 initModel, cmd
-            with
-            | e ->
+            with e ->
                 trace("Error in init function: {0}", $"%0A{e}")
                 reraise()
 
@@ -188,8 +165,7 @@ module Program =
                 let newModel, cmd = program.Update(msg, model)
                 trace("Updated model: {0}", $"%0A{newModel}")
                 newModel, cmd
-            with
-            | e ->
+            with e ->
                 trace("Error in model function: {0}", $"%0A{e}")
                 reraise()
 
@@ -200,24 +176,20 @@ module Program =
                 let info = program.View(model)
                 trace("View result: {0}", $"%0A{info}")
                 info
-            with
-            | e ->
+            with e ->
                 trace("Error in view function: {0}", $"%0A{e}")
                 reraise()
 
         { program with
-              Init = traceInit
-              Update = traceUpdate
-              View = traceView }
+            Init = traceInit
+            Update = traceUpdate
+            View = traceView }
 
     /// Configure how the unhandled exceptions happening during the execution of a Fabulous app with be handled
     let withExceptionHandler (handler: exn -> bool) (program: Program<'arg, 'model, 'msg, 'marker>) =
-        { program with
-              ExceptionHandler = handler }
+        { program with ExceptionHandler = handler }
 
 [<RequireQualifiedAccess>]
 module CmdMsg =
     let batch mapCmdMsgFn mapCmdFn cmdMsgs =
-        cmdMsgs
-        |> List.map(mapCmdMsgFn >> Cmd.map mapCmdFn)
-        |> Cmd.batch
+        cmdMsgs |> List.map(mapCmdMsgFn >> Cmd.map mapCmdFn) |> Cmd.batch

--- a/src/Fabulous.XamarinForms/README.md
+++ b/src/Fabulous.XamarinForms/README.md
@@ -4,36 +4,21 @@ Fabulous.XamarinForms brings the great development experience of Fabulous to Xam
 
 Deploy to any platform supported by Xamarin.Forms, such as Android, iOS, macOS, Windows, Linux and more!
 
-```fs
-/// A simple Counter app
+### Getting Started
 
-type Model =
-    { Count: int }
+You can start your new Fabulous.XamarinForms app in a matter of seconds using the dotnet CLI templates.  
+For a starter guide see our [documentation](https://docs.fabulous.dev/v2/xamarin.forms/getting-started).
 
-type Msg =
-    | Increment
-    | Decrement
-
-let init () =
-    { Count = 0 }
-
-let update msg model =
-    match msg with
-    | Increment -> { model with Count = model.Count + 1 }
-    | Decrement -> { model with Count = model.Count - 1 }
-
-let view model =
-    Application(
-        ContentPage(
-            "Counter app",
-            VStack(spacing = 16.) {
-                Image(Aspect.AspectFit, "fabulous.png")
-
-                Label($"Count is {model.Count}")
-
-                Button("Increment", Increment)
-                Button("Decrement", Decrement)
-            }
-        )
-    )
+```sh
+dotnet new install Fabulous.XamarinForms.Templates
+dotnet new fabulous-xf -n MyApp
 ```
+
+If you are developing with Visual Studio on Windows, use the `fabulous-xf-vswin` template instead.
+```sh
+dotnet new fabulous-xf-vswin -n MyApp
+```
+
+### Documentation
+
+Documentation can be found at https://docs.fabulous.dev/v2/xamarin.forms

--- a/src/Fabulous.XamarinForms/ViewNode.fs
+++ b/src/Fabulous.XamarinForms/ViewNode.fs
@@ -8,10 +8,7 @@ module ViewNode =
         BindableProperty.Create("ViewNode", typeof<ViewNode>, typeof<View>, null)
 
     let get (target: obj) =
-        (target :?> BindableObject)
-            .GetValue(ViewNodeProperty)
-        :?> IViewNode
+        (target :?> BindableObject).GetValue(ViewNodeProperty) :?> IViewNode
 
     let set (node: IViewNode) (target: obj) =
-        (target :?> BindableObject)
-            .SetValue(ViewNodeProperty, node)
+        (target :?> BindableObject).SetValue(ViewNodeProperty, node)

--- a/src/Fabulous.XamarinForms/Views/Any.fs
+++ b/src/Fabulous.XamarinForms/Views/Any.fs
@@ -6,6 +6,7 @@ open Fabulous.XamarinForms
 [<AutoOpen>]
 module AnyBuilders =
     type Fabulous.XamarinForms.View with
+
         /// Downcast to IView to allow to return different types of views in a single expression (e.g. if/else, match with pattern, etc.)
         static member AnyView<'msg, 'marker when 'marker :> IView>(widget: WidgetBuilder<'msg, 'marker>) =
             WidgetBuilder<'msg, IView>(widget.Key, widget.Attributes)

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -17,55 +17,41 @@ module Application =
             (fun target value -> (target :?> Application).MainPage <- value)
 
     let Resources =
-        Attributes.defineSimpleScalarWithEquality<ResourceDictionary>
-            "Application_Resources"
-            (fun _ newValueOpt node ->
-                let application = node.Target :?> Application
+        Attributes.defineSimpleScalarWithEquality<ResourceDictionary> "Application_Resources" (fun _ newValueOpt node ->
+            let application = node.Target :?> Application
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> application.Resources
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> application.Resources
+                | ValueSome v -> v
 
-                application.Resources <- value)
+            application.Resources <- value)
 
     let UserAppTheme =
-        Attributes.defineEnum<OSAppTheme>
-            "Application_UserAppTheme"
-            (fun _ newValueOpt node ->
-                let application = node.Target :?> Application
+        Attributes.defineEnum<OSAppTheme> "Application_UserAppTheme" (fun _ newValueOpt node ->
+            let application = node.Target :?> Application
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> OSAppTheme.Unspecified
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> OSAppTheme.Unspecified
+                | ValueSome v -> v
 
-                application.UserAppTheme <- value)
+            application.UserAppTheme <- value)
 
     let RequestedThemeChanged =
-        Attributes.defineEvent<AppThemeChangedEventArgs>
-            "Application_RequestedThemeChanged"
-            (fun target -> (target :?> Application).RequestedThemeChanged)
+        Attributes.defineEvent<AppThemeChangedEventArgs> "Application_RequestedThemeChanged" (fun target -> (target :?> Application).RequestedThemeChanged)
 
     let ModalPopped =
-        Attributes.defineEvent<ModalPoppedEventArgs>
-            "Application_ModalPopped"
-            (fun target -> (target :?> Application).ModalPopped)
+        Attributes.defineEvent<ModalPoppedEventArgs> "Application_ModalPopped" (fun target -> (target :?> Application).ModalPopped)
 
     let ModalPopping =
-        Attributes.defineEvent<ModalPoppingEventArgs>
-            "Application_ModalPopping"
-            (fun target -> (target :?> Application).ModalPopping)
+        Attributes.defineEvent<ModalPoppingEventArgs> "Application_ModalPopping" (fun target -> (target :?> Application).ModalPopping)
 
     let ModalPushed =
-        Attributes.defineEvent<ModalPushedEventArgs>
-            "Application_ModalPushed"
-            (fun target -> (target :?> Application).ModalPushed)
+        Attributes.defineEvent<ModalPushedEventArgs> "Application_ModalPushed" (fun target -> (target :?> Application).ModalPushed)
 
     let ModalPushing =
-        Attributes.defineEvent<ModalPushingEventArgs>
-            "Application_ModalPushing"
-            (fun target -> (target :?> Application).ModalPushing)
+        Attributes.defineEvent<ModalPushingEventArgs> "Application_ModalPushing" (fun target -> (target :?> Application).ModalPushing)
 
     let Start =
         Attributes.defineEventNoArg "Application_Start" (fun target -> (target :?> CustomApplication).Start)
@@ -79,10 +65,9 @@ module Application =
 [<AutoOpen>]
 module ApplicationBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Application<'msg, 'marker when 'marker :> IPage>(mainPage: WidgetBuilder<'msg, 'marker>) =
-            WidgetHelpers.buildWidgets<'msg, IApplication>
-                Application.WidgetKey
-                [| Application.MainPage.WithValue(mainPage.Compile()) |]
+            WidgetHelpers.buildWidgets<'msg, IApplication> Application.WidgetKey [| Application.MainPage.WithValue(mainPage.Compile()) |]
 
 [<Extension>]
 type ApplicationModifiers =
@@ -95,45 +80,23 @@ type ApplicationModifiers =
         this.AddScalar(Application.Resources.WithValue(value))
 
     [<Extension>]
-    static member inline onRequestedThemeChanged
-        (
-            this: WidgetBuilder<'msg, #IApplication>,
-            onRequestedThemeChanged: OSAppTheme -> 'msg
-        ) =
-        this.AddScalar(
-            Application.RequestedThemeChanged.WithValue(fun args -> onRequestedThemeChanged args.RequestedTheme |> box)
-        )
+    static member inline onRequestedThemeChanged(this: WidgetBuilder<'msg, #IApplication>, onRequestedThemeChanged: OSAppTheme -> 'msg) =
+        this.AddScalar(Application.RequestedThemeChanged.WithValue(fun args -> onRequestedThemeChanged args.RequestedTheme |> box))
 
     [<Extension>]
-    static member inline onModalPopped
-        (
-            this: WidgetBuilder<'msg, #IApplication>,
-            onModalPopped: ModalPoppedEventArgs -> 'msg
-        ) =
+    static member inline onModalPopped(this: WidgetBuilder<'msg, #IApplication>, onModalPopped: ModalPoppedEventArgs -> 'msg) =
         this.AddScalar(Application.ModalPopped.WithValue(onModalPopped >> box))
 
     [<Extension>]
-    static member inline onModalPopping
-        (
-            this: WidgetBuilder<'msg, #IApplication>,
-            onModalPopping: ModalPoppingEventArgs -> 'msg
-        ) =
+    static member inline onModalPopping(this: WidgetBuilder<'msg, #IApplication>, onModalPopping: ModalPoppingEventArgs -> 'msg) =
         this.AddScalar(Application.ModalPopping.WithValue(onModalPopping >> box))
 
     [<Extension>]
-    static member inline onModalPushed
-        (
-            this: WidgetBuilder<'msg, #IApplication>,
-            onModalPushed: ModalPushedEventArgs -> 'msg
-        ) =
+    static member inline onModalPushed(this: WidgetBuilder<'msg, #IApplication>, onModalPushed: ModalPushedEventArgs -> 'msg) =
         this.AddScalar(Application.ModalPushed.WithValue(onModalPushed >> box))
 
     [<Extension>]
-    static member inline onModalPushing
-        (
-            this: WidgetBuilder<'msg, #IApplication>,
-            onModalPushing: ModalPushingEventArgs -> 'msg
-        ) =
+    static member inline onModalPushing(this: WidgetBuilder<'msg, #IApplication>, onModalPushing: ModalPushingEventArgs -> 'msg) =
         this.AddScalar(Application.ModalPushing.WithValue(onModalPushing >> box))
 
     /// Dispatch a message when the application starts

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -10,11 +10,9 @@ type IEntryCell =
 module EntryCell =
     let WidgetKey = Widgets.register<CustomEntryCell>()
 
-    let Label =
-        Attributes.defineBindableWithEquality<string> EntryCell.LabelProperty
+    let Label = Attributes.defineBindableWithEquality<string> EntryCell.LabelProperty
 
-    let LabelColor =
-        Attributes.defineBindableAppThemeColor EntryCell.LabelColorProperty
+    let LabelColor = Attributes.defineBindableAppThemeColor EntryCell.LabelColorProperty
 
     let Placeholder =
         Attributes.defineBindableWithEquality<string> EntryCell.PlaceholderProperty
@@ -29,10 +27,7 @@ module EntryCell =
         Attributes.defineBindableWithEquality<Keyboard> EntryCell.KeyboardProperty
 
     let TextWithEvent =
-        Attributes.defineBindableWithEvent
-            "EntryCell_TextChanged"
-            EntryCell.TextProperty
-            (fun target -> (target :?> CustomEntryCell).TextChanged)
+        Attributes.defineBindableWithEvent "EntryCell_TextChanged" EntryCell.TextProperty (fun target -> (target :?> CustomEntryCell).TextChanged)
 
     let OnCompleted =
         Attributes.defineEventNoArg "EntryCell_Completed" (fun target -> (target :?> EntryCell).Completed)
@@ -41,13 +36,12 @@ module EntryCell =
 module EntryCellBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline EntryCell<'msg>(label: string, text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IEntryCell>(
                 EntryCell.WidgetKey,
                 EntryCell.Label.WithValue(label),
-                EntryCell.TextWithEvent.WithValue(
-                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
-                )
+                EntryCell.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Cells/ImageCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/ImageCell.fs
@@ -18,12 +18,9 @@ module ImageCell =
 [<AutoOpen>]
 module ImageCellBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ImageCell<'msg>(text: string, light: ImageSource, ?dark: ImageSource) =
-            WidgetBuilder<'msg, IImageCell>(
-                ImageCell.WidgetKey,
-                TextCell.Text.WithValue(text),
-                ImageCell.ImageSource.WithValue(AppTheme.create light dark)
-            )
+            WidgetBuilder<'msg, IImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(AppTheme.create light dark))
 
         static member inline ImageCell<'msg>(text: string, light: string, ?dark: string) =
             let light = ImageSource.FromFile(light)

--- a/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
@@ -10,21 +10,17 @@ type ISwitchCell =
 module SwitchCell =
     let WidgetKey = Widgets.register<SwitchCell>()
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> SwitchCell.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> SwitchCell.TextProperty
 
     let OnWithEvent =
-        Attributes.defineBindableWithEvent
-            "SwitchCell_OnChanged"
-            SwitchCell.OnProperty
-            (fun target -> (target :?> SwitchCell).OnChanged)
+        Attributes.defineBindableWithEvent "SwitchCell_OnChanged" SwitchCell.OnProperty (fun target -> (target :?> SwitchCell).OnChanged)
 
-    let OnColor =
-        Attributes.defineBindableAppThemeColor SwitchCell.OnColorProperty
+    let OnColor = Attributes.defineBindableAppThemeColor SwitchCell.OnColorProperty
 
 [<AutoOpen>]
 module SwitchCellBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline SwitchCell<'msg>(text: string, value: bool, onChanged: bool -> 'msg) =
             WidgetBuilder<'msg, ISwitchCell>(
                 SwitchCell.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Cells/TextCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/TextCell.fs
@@ -10,14 +10,11 @@ type ITextCell =
 module TextCell =
     let WidgetKey = Widgets.register<TextCell>()
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> TextCell.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> TextCell.TextProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor TextCell.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor TextCell.TextColorProperty
 
-    let Detail =
-        Attributes.defineBindableWithEquality<string> TextCell.DetailProperty
+    let Detail = Attributes.defineBindableWithEquality<string> TextCell.DetailProperty
 
     let DetailColor =
         Attributes.defineBindableAppThemeColor TextCell.DetailColorProperty
@@ -25,6 +22,7 @@ module TextCell =
 [<AutoOpen>]
 module TextCellBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline TextCell<'msg>(text: string) =
             WidgetBuilder<'msg, ITextCell>(TextCell.WidgetKey, TextCell.Text.WithValue(text))
 

--- a/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
@@ -19,6 +19,7 @@ module ViewCell =
 [<AutoOpen>]
 module ViewCellBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ViewCell<'msg, 'marker when 'marker :> IView>(view: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IViewCell> ViewCell.WidgetKey [| ViewCell.View.WithValue(view.Compile()) |]
 

--- a/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
@@ -8,21 +8,18 @@ type ICell =
     inherit IElement
 
 module Cell =
-    let IsEnabled =
-        Attributes.defineBindableBool Cell.IsEnabledProperty
+    let IsEnabled = Attributes.defineBindableBool Cell.IsEnabledProperty
 
     let Height =
-        Attributes.defineFloat
-            "Cell_Height"
-            (fun _ newValueOpt node ->
-                let cell = node.Target :?> Cell
+        Attributes.defineFloat "Cell_Height" (fun _ newValueOpt node ->
+            let cell = node.Target :?> Cell
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> cell.Height
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> cell.Height
+                | ValueSome v -> v
 
-                cell.Height <- value)
+            cell.Height <- value)
 
     let Appearing =
         Attributes.defineEventNoArg "Cell_Appearing" (fun target -> (target :?> Cell).Appearing)

--- a/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
@@ -14,8 +14,7 @@ module CarouselView =
     let IsBounceEnabled =
         Attributes.defineBindableBool CarouselView.IsBounceEnabledProperty
 
-    let IsDragging =
-        Attributes.defineBindableBool CarouselView.IsDraggingProperty
+    let IsDragging = Attributes.defineBindableBool CarouselView.IsDraggingProperty
 
     let IsScrollAnimated =
         Attributes.defineBindableBool CarouselView.IsScrollAnimatedProperty
@@ -23,74 +22,65 @@ module CarouselView =
     let IsSwipeEnabled =
         Attributes.defineBindableBool CarouselView.IsSwipeEnabledProperty
 
-    let Loop =
-        Attributes.defineBindableBool CarouselView.LoopProperty
+    let Loop = Attributes.defineBindableBool CarouselView.LoopProperty
 
     let PeekAreaInsets =
         Attributes.defineBindableWithEquality<Thickness> CarouselView.PeekAreaInsetsProperty
 
     let IndicatorView =
-        Attributes.defineSimpleScalarWithEquality<ViewRef<IndicatorView>>
-            "CarouselView_IndicatorView"
-            (fun oldValueOpt newValueOpt node ->
-                let handlerOpt =
-                    node.TryGetHandler<EventHandler<IndicatorView>>(ViewRefAttributes.ViewRef.Name)
+        Attributes.defineSimpleScalarWithEquality<ViewRef<IndicatorView>> "CarouselView_IndicatorView" (fun oldValueOpt newValueOpt node ->
+            let handlerOpt =
+                node.TryGetHandler<EventHandler<IndicatorView>>(ViewRefAttributes.ViewRef.Name)
 
-                // Clean up previous handler
-                if handlerOpt.IsSome then
-                    match struct (oldValueOpt, newValueOpt) with
-                    | struct (ValueSome prev, _) -> prev.Attached.RemoveHandler(handlerOpt.Value)
+            // Clean up previous handler
+            if handlerOpt.IsSome then
+                match struct (oldValueOpt, newValueOpt) with
+                | struct (ValueSome prev, _) -> prev.Attached.RemoveHandler(handlerOpt.Value)
 
-                    | struct (ValueNone, ValueSome curr) ->
-                        // Despite not having a previous value, we might still be reusing the same ViewRef
-                        // So we still need to clean up
-                        curr.Attached.RemoveHandler(handlerOpt.Value)
+                | struct (ValueNone, ValueSome curr) ->
+                    // Despite not having a previous value, we might still be reusing the same ViewRef
+                    // So we still need to clean up
+                    curr.Attached.RemoveHandler(handlerOpt.Value)
 
-                    | struct (ValueNone, ValueNone) -> ()
+                | struct (ValueNone, ValueNone) -> ()
 
-                    node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueNone)
+                node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueNone)
 
-                let handler =
-                    match handlerOpt with
-                    | ValueSome handler -> handler
-                    | ValueNone ->
-                        let newHandler =
-                            EventHandler<IndicatorView>
-                                (fun viewRef indicatorView ->
-                                    let carouselView = node.Target :?> CarouselView
+            let handler =
+                match handlerOpt with
+                | ValueSome handler -> handler
+                | ValueNone ->
+                    let newHandler =
+                        EventHandler<IndicatorView>(fun viewRef indicatorView ->
+                            let carouselView = node.Target :?> CarouselView
 
-                                    if carouselView <> null then
-                                        carouselView.IndicatorView <- indicatorView
-                                    else
-                                        // CarouselView has been disposed, clean up the handler
-                                        let handler =
-                                            node
-                                                .TryGetHandler<EventHandler<IndicatorView>>(
-                                                    ViewRefAttributes.ViewRef.Name
-                                                )
-                                                .Value
+                            if carouselView <> null then
+                                carouselView.IndicatorView <- indicatorView
+                            else
+                                // CarouselView has been disposed, clean up the handler
+                                let handler =
+                                    node
+                                        .TryGetHandler<EventHandler<IndicatorView>>(
+                                            ViewRefAttributes.ViewRef.Name
+                                        )
+                                        .Value
 
-                                        (viewRef :?> ViewRef<IndicatorView>)
-                                            .Attached.RemoveHandler(handler))
+                                (viewRef :?> ViewRef<IndicatorView>).Attached.RemoveHandler(handler))
 
-                        newHandler
+                    newHandler
 
-                match newValueOpt with
-                | ValueNone -> node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueNone)
-                | ValueSome curr ->
-                    curr.Attached.AddHandler(handler)
-                    node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueSome handler))
+            match newValueOpt with
+            | ValueNone -> node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueNone)
+            | ValueSome curr ->
+                curr.Attached.AddHandler(handler)
+                node.SetHandler(ViewRefAttributes.ViewRef.Name, ValueSome handler))
 
 [<AutoOpen>]
 module CarouselViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IView>
-            (items: seq<'itemData>)
-            =
-            WidgetHelpers.buildItems<'msg, ICarouselView, 'itemData, 'itemMarker>
-                CarouselView.WidgetKey
-                ItemsView.ItemsSource
-                items
+
+        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IView>(items: seq<'itemData>) =
+            WidgetHelpers.buildItems<'msg, ICarouselView, 'itemData, 'itemMarker> CarouselView.WidgetKey ItemsView.ItemsSource items
 
 [<Extension>]
 type CarouselViewModifiers =
@@ -133,14 +123,7 @@ type CarouselViewModifiers =
         CarouselViewModifiers.peekAreaInsets(this, Thickness(value))
 
     [<Extension>]
-    static member inline peekAreaInsets
-        (
-            this: WidgetBuilder<'msg, #ICarouselView>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline peekAreaInsets(this: WidgetBuilder<'msg, #ICarouselView>, left: float, top: float, right: float, bottom: float) =
         CarouselViewModifiers.peekAreaInsets(this, Thickness(left, top, right, bottom))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
@@ -28,15 +28,9 @@ module CollectionView =
                 | ValueSome value ->
                     collectionView.IsGrouped <- true
 
-                    collectionView.SetValue(
-                        CollectionView.ItemTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.ItemTemplate)
-                    )
+                    collectionView.SetValue(CollectionView.ItemTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.ItemTemplate))
 
-                    collectionView.SetValue(
-                        CollectionView.GroupHeaderTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.HeaderTemplate)
-                    )
+                    collectionView.SetValue(CollectionView.GroupHeaderTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.HeaderTemplate))
 
                     if value.FooterTemplate.IsSome then
                         collectionView.SetValue(
@@ -49,32 +43,25 @@ module CollectionView =
     let SelectionMode =
         Attributes.defineBindableEnum<SelectionMode> CollectionView.SelectionModeProperty
 
-    let Header =
-        Attributes.defineBindableWidget CollectionView.HeaderProperty
+    let Header = Attributes.defineBindableWidget CollectionView.HeaderProperty
 
-    let Footer =
-        Attributes.defineBindableWidget CollectionView.FooterProperty
+    let Footer = Attributes.defineBindableWidget CollectionView.FooterProperty
 
     let ItemSizingStrategy =
         Attributes.defineBindableEnum<ItemSizingStrategy> CollectionView.ItemSizingStrategyProperty
 
     let SelectionChanged =
-        Attributes.defineEvent<SelectionChangedEventArgs>
-            "CollectionView_SelectionChanged"
-            (fun target -> (target :?> CollectionView).SelectionChanged)
+        Attributes.defineEvent<SelectionChangedEventArgs> "CollectionView_SelectionChanged" (fun target -> (target :?> CollectionView).SelectionChanged)
 
 [<AutoOpen>]
 module CollectionViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline CollectionView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IView>
-            (items: seq<'itemData>)
-            =
-            WidgetHelpers.buildItems<'msg, ICollectionView, 'itemData, 'itemMarker>
-                CollectionView.WidgetKey
-                ItemsView.ItemsSource
-                items
 
-        static member inline GroupedCollectionView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker when 'itemMarker :> IView and 'groupMarker :> IView and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
+        static member inline CollectionView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IView>(items: seq<'itemData>) =
+            WidgetHelpers.buildItems<'msg, ICollectionView, 'itemData, 'itemMarker> CollectionView.WidgetKey ItemsView.ItemsSource items
+
+        static member inline GroupedCollectionView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker
+            when 'itemMarker :> IView and 'groupMarker :> IView and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
             (items: seq<'groupData>)
             =
             WidgetHelpers.buildGroupItems<'msg, ICollectionView, 'groupData, 'itemData, 'groupMarker, 'itemMarker>
@@ -90,11 +77,7 @@ type CollectionViewModifiers =
         this.AddScalar(CollectionView.SelectionMode.WithValue(value))
 
     [<Extension>]
-    static member inline onSelectionChanged
-        (
-            this: WidgetBuilder<'msg, #ICollectionView>,
-            onSelectionChanged: SelectionChangedEventArgs -> 'msg
-        ) =
+    static member inline onSelectionChanged(this: WidgetBuilder<'msg, #ICollectionView>, onSelectionChanged: SelectionChangedEventArgs -> 'msg) =
         this.AddScalar(CollectionView.SelectionChanged.WithValue(fun args -> onSelectionChanged args |> box))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -31,24 +31,15 @@ module ListView =
 
                     listView.SetValue(ListView.ItemsSourceProperty, value.OriginalItems)
 
-                    listView.SetValue(
-                        ListView.ItemTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.ItemTemplate)
-                    )
+                    listView.SetValue(ListView.ItemTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.ItemTemplate))
 
-                    listView.SetValue(
-                        ListView.GroupHeaderTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.HeaderTemplate)
-                    ))
+                    listView.SetValue(ListView.GroupHeaderTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.HeaderTemplate)))
 
-    let Header =
-        Attributes.defineBindableWidget ListView.HeaderProperty
+    let Header = Attributes.defineBindableWidget ListView.HeaderProperty
 
-    let Footer =
-        Attributes.defineBindableWidget ListView.FooterProperty
+    let Footer = Attributes.defineBindableWidget ListView.FooterProperty
 
-    let RowHeight =
-        Attributes.defineBindableInt ListView.RowHeightProperty
+    let RowHeight = Attributes.defineBindableInt ListView.RowHeightProperty
 
     let SelectionMode =
         Attributes.defineBindableEnum<ListViewSelectionMode> ListView.SelectionModeProperty
@@ -56,11 +47,9 @@ module ListView =
     let IsPullToRefreshEnabled =
         Attributes.defineBindableBool ListView.IsPullToRefreshEnabledProperty
 
-    let IsRefreshing =
-        Attributes.defineBindableBool ListView.IsRefreshingProperty
+    let IsRefreshing = Attributes.defineBindableBool ListView.IsRefreshingProperty
 
-    let HasUnevenRows =
-        Attributes.defineBindableBool ListView.HasUnevenRowsProperty
+    let HasUnevenRows = Attributes.defineBindableBool ListView.HasUnevenRowsProperty
 
     let SeparatorVisibility =
         Attributes.defineBindableEnum<SeparatorVisibility> ListView.SeparatorVisibilityProperty
@@ -78,24 +67,16 @@ module ListView =
         Attributes.defineBindableEnum<ScrollBarVisibility> ListView.VerticalScrollBarVisibilityProperty
 
     let ItemAppearing =
-        Attributes.defineEvent<ItemVisibilityEventArgs>
-            "ListView_ItemAppearing"
-            (fun target -> (target :?> ListView).ItemAppearing)
+        Attributes.defineEvent<ItemVisibilityEventArgs> "ListView_ItemAppearing" (fun target -> (target :?> ListView).ItemAppearing)
 
     let ItemDisappearing =
-        Attributes.defineEvent<ItemVisibilityEventArgs>
-            "ListView_ItemDisappearing"
-            (fun target -> (target :?> ListView).ItemDisappearing)
+        Attributes.defineEvent<ItemVisibilityEventArgs> "ListView_ItemDisappearing" (fun target -> (target :?> ListView).ItemDisappearing)
 
     let ItemSelected =
-        Attributes.defineEvent<SelectedItemChangedEventArgs>
-            "ListView_ItemSelected"
-            (fun target -> (target :?> ListView).ItemSelected)
+        Attributes.defineEvent<SelectedItemChangedEventArgs> "ListView_ItemSelected" (fun target -> (target :?> ListView).ItemSelected)
 
     let ItemTapped =
-        Attributes.defineEvent<ItemTappedEventArgs>
-            "ListView_ItemTapped"
-            (fun target -> (target :?> ListView).ItemTapped)
+        Attributes.defineEvent<ItemTappedEventArgs> "ListView_ItemTapped" (fun target -> (target :?> ListView).ItemTapped)
 
     let Refreshing =
         Attributes.defineEventNoArg "ListView_Refreshing" (fun target -> (target :?> ListView).Refreshing)
@@ -104,20 +85,17 @@ module ListView =
         Attributes.defineEvent<ScrolledEventArgs> "ListView_Scrolled" (fun target -> (target :?> ListView).Scrolled)
 
     let ScrollToRequested =
-        Attributes.defineEvent<ScrollToRequestedEventArgs>
-            "ListView_ScrollToRequested"
-            (fun target -> (target :?> ListView).ScrollToRequested)
+        Attributes.defineEvent<ScrollToRequestedEventArgs> "ListView_ScrollToRequested" (fun target -> (target :?> ListView).ScrollToRequested)
 
 [<AutoOpen>]
 module ListViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline ListView<'msg, 'itemData, 'itemMarker when 'itemMarker :> ICell>(items: seq<'itemData>) =
-            WidgetHelpers.buildItems<'msg, IListView, 'itemData, 'itemMarker>
-                ListView.WidgetKey
-                ItemsViewOfCell.ItemsSource
-                items
 
-        static member inline GroupedListView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker when 'itemMarker :> ICell and 'groupMarker :> ICell and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
+        static member inline ListView<'msg, 'itemData, 'itemMarker when 'itemMarker :> ICell>(items: seq<'itemData>) =
+            WidgetHelpers.buildItems<'msg, IListView, 'itemData, 'itemMarker> ListView.WidgetKey ItemsViewOfCell.ItemsSource items
+
+        static member inline GroupedListView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker
+            when 'itemMarker :> ICell and 'groupMarker :> ICell and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
             (items: seq<'groupData>)
             =
             WidgetHelpers.buildGroupItemsNoFooter<'msg, IListView, 'groupData, 'itemData, 'groupMarker, 'itemMarker>
@@ -149,19 +127,11 @@ type ListViewModifiers =
         this.AddScalar(ListView.HasUnevenRows.WithValue(value))
 
     [<Extension>]
-    static member inline horizontalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline horizontalScrollBarVisibility(this: WidgetBuilder<'msg, #IListView>, value: ScrollBarVisibility) =
         this.AddScalar(ListView.HorizontalScrollBarVisibility.WithValue(value))
 
     [<Extension>]
-    static member inline verticalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline verticalScrollBarVisibility(this: WidgetBuilder<'msg, #IListView>, value: ScrollBarVisibility) =
         this.AddScalar(ListView.VerticalScrollBarVisibility.WithValue(value))
 
     [<Extension>]
@@ -193,19 +163,11 @@ type ListViewModifiers =
         this.AddScalar(ListView.SelectionMode.WithValue(value))
 
     [<Extension>]
-    static member inline onItemAppearing
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            onItemAppearing: ItemVisibilityEventArgs -> 'msg
-        ) =
+    static member inline onItemAppearing(this: WidgetBuilder<'msg, #IListView>, onItemAppearing: ItemVisibilityEventArgs -> 'msg) =
         this.AddScalar(ListView.ItemAppearing.WithValue(fun args -> onItemAppearing args |> box))
 
     [<Extension>]
-    static member inline onItemDisappearing
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            onItemDisappearing: ItemVisibilityEventArgs -> 'msg
-        ) =
+    static member inline onItemDisappearing(this: WidgetBuilder<'msg, #IListView>, onItemDisappearing: ItemVisibilityEventArgs -> 'msg) =
         this.AddScalar(ListView.ItemDisappearing.WithValue(fun args -> onItemDisappearing args |> box))
 
     [<Extension>]
@@ -213,11 +175,7 @@ type ListViewModifiers =
         this.AddScalar(ListView.ItemTapped.WithValue(fun args -> onItemTapped args.ItemIndex |> box))
 
     [<Extension; Obsolete("Use onItemSelected(int -> 'msg) instead")>]
-    static member inline onItemSelected
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            onItemSelected: SelectedItemChangedEventArgs -> 'msg
-        ) =
+    static member inline onItemSelected(this: WidgetBuilder<'msg, #IListView>, onItemSelected: SelectedItemChangedEventArgs -> 'msg) =
         this.AddScalar(ListView.ItemSelected.WithValue(fun args -> onItemSelected args |> box))
 
     [<Extension>]
@@ -233,11 +191,7 @@ type ListViewModifiers =
         this.AddScalar(ListView.Scrolled.WithValue(fun args -> onScrolled args |> box))
 
     [<Extension>]
-    static member inline onScrollToRequested
-        (
-            this: WidgetBuilder<'msg, #IListView>,
-            onScrollToRequested: ScrollToRequestedEventArgs -> 'msg
-        ) =
+    static member inline onScrollToRequested(this: WidgetBuilder<'msg, #IListView>, onScrollToRequested: ScrollToRequestedEventArgs -> 'msg) =
         this.AddScalar(ListView.ScrollToRequested.WithValue(fun args -> onScrollToRequested args |> box))
 
     /// <summary>Link a ViewRef to access the direct ListView control instance</summary>

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
@@ -20,25 +20,17 @@ module ItemsView =
                     itemsView.ClearValue(ItemsView.ItemTemplateProperty)
                     itemsView.ClearValue(ItemsView.ItemsSourceProperty)
                 | ValueSome value ->
-                    itemsView.SetValue(
-                        ItemsView.ItemTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.Template)
-                    )
+                    itemsView.SetValue(ItemsView.ItemTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.Template))
 
                     itemsView.SetValue(ItemsView.ItemsSourceProperty, value.OriginalItems))
 
-    let EmptyView =
-        Attributes.defineBindableWidget ItemsView.EmptyViewProperty
+    let EmptyView = Attributes.defineBindableWidget ItemsView.EmptyViewProperty
 
     let RemainingItemsThreshold =
         Attributes.defineBindableInt ItemsView.RemainingItemsThresholdProperty
 
     let RemainingItemsThresholdReached =
-        Attributes.defineEventNoArg
-            "ItemsView_RemainingItemsThresholdReached"
-            (fun target ->
-                (target :?> ItemsView)
-                    .RemainingItemsThresholdReached)
+        Attributes.defineEventNoArg "ItemsView_RemainingItemsThresholdReached" (fun target -> (target :?> ItemsView).RemainingItemsThresholdReached)
 
     let HorizontalScrollBarVisibility =
         Attributes.defineBindableEnum<ScrollBarVisibility> ItemsView.HorizontalScrollBarVisibilityProperty
@@ -50,14 +42,10 @@ module ItemsView =
         Attributes.defineBindableEnum<ItemsUpdatingScrollMode> ItemsView.ItemsUpdatingScrollModeProperty
 
     let ScrollToRequested =
-        Attributes.defineEvent<ScrollToRequestEventArgs>
-            "ItemsView_ScrolledRequested"
-            (fun target -> (target :?> ItemsView).ScrollToRequested)
+        Attributes.defineEvent<ScrollToRequestEventArgs> "ItemsView_ScrolledRequested" (fun target -> (target :?> ItemsView).ScrollToRequested)
 
     let Scrolled =
-        Attributes.defineEvent<ItemsViewScrolledEventArgs>
-            "ItemsView_Scrolled"
-            (fun target -> (target :?> ItemsView).Scrolled)
+        Attributes.defineEvent<ItemsViewScrolledEventArgs> "ItemsView_Scrolled" (fun target -> (target :?> ItemsView).Scrolled)
 
 [<Extension>]
 type ItemsViewModifiers =
@@ -66,12 +54,7 @@ type ItemsViewModifiers =
     /// <param name="value">The threshold of items not yet visible in the list</param>
     /// <param="onThresholdReached">Event executed when the RemainingItemsThreshold is reached</param>
     [<Extension>]
-    static member inline remainingItemsThreshold
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            value: int,
-            onThresholdReached: 'msg
-        ) =
+    static member inline remainingItemsThreshold(this: WidgetBuilder<'msg, #IItemsView>, value: int, onThresholdReached: 'msg) =
         this
             .AddScalar(ItemsView.RemainingItemsThreshold.WithValue(value))
             .AddScalar(ItemsView.RemainingItemsThresholdReached.WithValue(onThresholdReached))
@@ -79,45 +62,25 @@ type ItemsViewModifiers =
     /// <summary>Sets the visibility of the horizontal scroll bar.</summary>
     /// <param name="value">true if the horizontal scroll is enabled; otherwise, false.</param>
     [<Extension>]
-    static member inline horizontalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline horizontalScrollBarVisibility(this: WidgetBuilder<'msg, #IItemsView>, value: ScrollBarVisibility) =
         this.AddScalar(ItemsView.HorizontalScrollBarVisibility.WithValue(value))
 
     /// <summary>Sets the visibility of the vertical scroll bar.</summary>
     /// <param name="value">true if the vertical scroll is enabled; otherwise, false.</param>
     [<Extension>]
-    static member inline verticalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline verticalScrollBarVisibility(this: WidgetBuilder<'msg, #IItemsView>, value: ScrollBarVisibility) =
         this.AddScalar(ItemsView.VerticalScrollBarVisibility.WithValue(value))
 
     [<Extension>]
-    static member inline itemsUpdatingScrollMode
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            value: ItemsUpdatingScrollMode
-        ) =
+    static member inline itemsUpdatingScrollMode(this: WidgetBuilder<'msg, #IItemsView>, value: ItemsUpdatingScrollMode) =
         this.AddScalar(ItemsView.ItemsUpdatingScrollMode.WithValue(value))
 
     [<Extension>]
-    static member inline onScrollToRequested
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            onScrollToRequested: ScrollToRequestEventArgs -> 'msg
-        ) =
+    static member inline onScrollToRequested(this: WidgetBuilder<'msg, #IItemsView>, onScrollToRequested: ScrollToRequestEventArgs -> 'msg) =
         this.AddScalar(ItemsView.ScrollToRequested.WithValue(fun args -> onScrollToRequested args |> box))
 
     [<Extension>]
-    static member inline onScrolled
-        (
-            this: WidgetBuilder<'msg, #IItemsView>,
-            onScrolled: ItemsViewScrolledEventArgs -> 'msg
-        ) =
+    static member inline onScrolled(this: WidgetBuilder<'msg, #IItemsView>, onScrolled: ItemsViewScrolledEventArgs -> 'msg) =
         this.AddScalar(ItemsView.Scrolled.WithValue(fun args -> onScrolled args |> box))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
@@ -19,9 +19,6 @@ module ItemsViewOfCell =
                     itemsView.ClearValue(ItemsView<Cell>.ItemTemplateProperty)
                     itemsView.ClearValue(ItemsView<Cell>.ItemsSourceProperty)
                 | ValueSome value ->
-                    itemsView.SetValue(
-                        ItemsView<Cell>.ItemTemplateProperty,
-                        WidgetDataTemplateSelector(node, unbox >> value.Template)
-                    )
+                    itemsView.SetValue(ItemsView<Cell>.ItemTemplateProperty, WidgetDataTemplateSelector(node, unbox >> value.Template))
 
                     itemsView.SetValue(ItemsView<Cell>.ItemsSourceProperty, value.OriginalItems))

--- a/src/Fabulous.XamarinForms/Views/Controls/ActivityIndicator.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ActivityIndicator.fs
@@ -10,20 +10,16 @@ type IActivityIndicator =
 module ActivityIndicator =
     let WidgetKey = Widgets.register<ActivityIndicator>()
 
-    let IsRunning =
-        Attributes.defineBindableBool ActivityIndicator.IsRunningProperty
+    let IsRunning = Attributes.defineBindableBool ActivityIndicator.IsRunningProperty
 
-    let Color =
-        Attributes.defineBindableAppThemeColor ActivityIndicator.ColorProperty
+    let Color = Attributes.defineBindableAppThemeColor ActivityIndicator.ColorProperty
 
 [<AutoOpen>]
 module ActivityIndicatorBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ActivityIndicator<'msg>(isRunning: bool) =
-            WidgetBuilder<'msg, IActivityIndicator>(
-                ActivityIndicator.WidgetKey,
-                ActivityIndicator.IsRunning.WithValue(isRunning)
-            )
+            WidgetBuilder<'msg, IActivityIndicator>(ActivityIndicator.WidgetKey, ActivityIndicator.IsRunning.WithValue(isRunning))
 
 [<Extension>]
 type ActivityIndicatorModifiers =

--- a/src/Fabulous.XamarinForms/Views/Controls/BoxView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/BoxView.fs
@@ -10,15 +10,14 @@ type IBoxView =
 module BoxView =
     let WidgetKey = Widgets.register<BoxView>()
 
-    let Color =
-        Attributes.defineBindableAppThemeColor BoxView.ColorProperty
+    let Color = Attributes.defineBindableAppThemeColor BoxView.ColorProperty
 
-    let CornerRadius =
-        Attributes.defineBindableFloat BoxView.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableFloat BoxView.CornerRadiusProperty
 
 [<AutoOpen>]
 module BoxViewBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline BoxView<'msg>(light: FabColor, ?dark: FabColor) =
             WidgetBuilder<'msg, IBoxView>(BoxView.WidgetKey, BoxView.Color.WithValue(AppTheme.create light dark))
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Button.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Button.fs
@@ -12,11 +12,9 @@ type IButton =
 module Button =
     let WidgetKey = Widgets.register<Button>()
 
-    let BorderColor =
-        Attributes.defineBindableAppThemeColor Button.BorderColorProperty
+    let BorderColor = Attributes.defineBindableAppThemeColor Button.BorderColorProperty
 
-    let BorderWidth =
-        Attributes.defineBindableFloat Button.BorderWidthProperty
+    let BorderWidth = Attributes.defineBindableFloat Button.BorderWidthProperty
 
     let CharacterSpacing =
         Attributes.defineBindableFloat Button.CharacterSpacingProperty
@@ -24,8 +22,7 @@ module Button =
     let ContentLayout =
         Attributes.defineBindableWithEquality<Button.ButtonContentLayout> Button.ContentLayoutProperty
 
-    let CornerRadius =
-        Attributes.defineBindableInt Button.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableInt Button.CornerRadiusProperty
 
     let FontAttributes =
         Attributes.defineBindableEnum<FontAttributes> Button.FontAttributesProperty
@@ -33,8 +30,7 @@ module Button =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Button.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Button.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Button.FontSizeProperty
 
     let ImageSource =
         Attributes.defineBindableAppTheme<ImageSource> Button.ImageSourceProperty
@@ -42,11 +38,9 @@ module Button =
     let Padding =
         Attributes.defineBindableWithEquality<Thickness> Button.PaddingProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor Button.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor Button.TextColorProperty
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> Button.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> Button.TextProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> Button.TextTransformProperty
@@ -63,12 +57,9 @@ module Button =
 [<AutoOpen>]
 module ButtonBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Button<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IButton>(
-                Button.WidgetKey,
-                Button.Text.WithValue(text),
-                Button.Clicked.WithValue(onClicked)
-            )
+            WidgetBuilder<'msg, IButton>(Button.WidgetKey, Button.Text.WithValue(text), Button.Clicked.WithValue(onClicked))
 
 [<Extension>]
 type ButtonModifiers =
@@ -101,14 +92,7 @@ type ButtonModifiers =
         ButtonModifiers.padding(this, Thickness(value))
 
     [<Extension>]
-    static member inline padding
-        (
-            this: WidgetBuilder<'msg, #IButton>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline padding(this: WidgetBuilder<'msg, #IButton>, left: float, top: float, right: float, bottom: float) =
         ButtonModifiers.padding(this, Thickness(left, top, right, bottom))
 
     [<Extension>]
@@ -116,23 +100,11 @@ type ButtonModifiers =
         this.AddScalar(Button.CharacterSpacing.WithValue(value))
 
     [<Extension>]
-    static member inline contentLayout
-        (
-            this: WidgetBuilder<'msg, #IButton>,
-            position: Xamarin.Forms.Button.ButtonContentLayout.ImagePosition,
-            spacing: float
-        ) =
+    static member inline contentLayout(this: WidgetBuilder<'msg, #IButton>, position: Xamarin.Forms.Button.ButtonContentLayout.ImagePosition, spacing: float) =
         this.AddScalar(Button.ContentLayout.WithValue(Button.ButtonContentLayout(position, spacing)))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IButton>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IButton>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
@@ -11,24 +11,19 @@ module CheckBox =
 
     let WidgetKey = Widgets.register<CheckBox>()
 
-    let Color =
-        Attributes.defineBindableAppThemeColor CheckBox.ColorProperty
+    let Color = Attributes.defineBindableAppThemeColor CheckBox.ColorProperty
 
     let IsCheckedWithEvent =
-        Attributes.defineBindableWithEvent
-            "CheckBox_CheckedChanged"
-            CheckBox.IsCheckedProperty
-            (fun target -> (target :?> CheckBox).CheckedChanged)
+        Attributes.defineBindableWithEvent "CheckBox_CheckedChanged" CheckBox.IsCheckedProperty (fun target -> (target :?> CheckBox).CheckedChanged)
 
 [<AutoOpen>]
 module CheckBoxBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline CheckBox<'msg>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
             WidgetBuilder<'msg, ICheckBox>(
                 CheckBox.WidgetKey,
-                CheckBox.IsCheckedWithEvent.WithValue(
-                    ValueEventData.create isChecked (fun args -> onCheckedChanged args.Value |> box)
-                )
+                CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onCheckedChanged args.Value |> box))
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
@@ -21,11 +21,9 @@ module DatePicker =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> DatePicker.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat DatePicker.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat DatePicker.FontSizeProperty
 
-    let Format =
-        Attributes.defineBindableWithEquality<string> DatePicker.FormatProperty
+    let Format = Attributes.defineBindableWithEquality<string> DatePicker.FormatProperty
 
     let MaximumDate =
         Attributes.defineBindableWithEquality<DateTime> DatePicker.MaximumDateProperty
@@ -33,40 +31,33 @@ module DatePicker =
     let MinimumDate =
         Attributes.defineBindableWithEquality<DateTime> DatePicker.MinimumDateProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor DatePicker.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor DatePicker.TextColorProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<Xamarin.Forms.TextTransform> DatePicker.TextTransformProperty
 
     let DateWithEvent =
-        Attributes.defineBindableWithEvent
-            "DatePicker_DateSelected"
-            DatePicker.DateProperty
-            (fun target -> (target :?> DatePicker).DateSelected)
+        Attributes.defineBindableWithEvent "DatePicker_DateSelected" DatePicker.DateProperty (fun target -> (target :?> DatePicker).DateSelected)
 
     let UpdateMode =
-        Attributes.defineSimpleScalarWithEquality<iOSSpecific.UpdateMode>
-            "DatePicker_UpdateMode"
-            (fun _ newValueOpt node ->
-                let datePicker = node.Target :?> DatePicker
+        Attributes.defineSimpleScalarWithEquality<iOSSpecific.UpdateMode> "DatePicker_UpdateMode" (fun _ newValueOpt node ->
+            let datePicker = node.Target :?> DatePicker
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                | ValueSome v -> v
 
-                iOSSpecific.DatePicker.SetUpdateMode(datePicker, value))
+            iOSSpecific.DatePicker.SetUpdateMode(datePicker, value))
 
 [<AutoOpen>]
 module DatePickerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline DatePicker<'msg>(date: DateTime, onDateSelected: DateTime -> 'msg) =
             WidgetBuilder<'msg, IDatePicker>(
                 DatePicker.WidgetKey,
-                DatePicker.DateWithEvent.WithValue(
-                    ValueEventData.create date (fun args -> onDateSelected args.NewDate |> box)
-                )
+                DatePicker.DateWithEvent.WithValue(ValueEventData.create date (fun args -> onDateSelected args.NewDate |> box))
             )
 
 [<Extension>]
@@ -76,14 +67,7 @@ type DatePickerModifiers =
         this.AddScalar(DatePicker.CharacterSpacing.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IDatePicker>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IDatePicker>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
@@ -19,8 +19,7 @@ module Editor =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Editor.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Editor.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Editor.FontSizeProperty
 
     let IsTextPredictionEnabled =
         Attributes.defineBindableBool Editor.IsTextPredictionEnabledProperty
@@ -31,25 +30,17 @@ module Editor =
 [<AutoOpen>]
 module EditorBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IEditor>(
                 Editor.WidgetKey,
-                InputView.TextWithEvent.WithValue(
-                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
-                )
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
             )
 
 [<Extension>]
 type EditorModifiers =
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IEditor>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IEditor>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -14,8 +14,7 @@ module Entry =
     let ClearButtonVisibility =
         Attributes.defineBindableWithEquality<ClearButtonVisibility> Entry.ClearButtonVisibilityProperty
 
-    let CursorPosition =
-        Attributes.defineBindableInt Entry.CursorPositionProperty
+    let CursorPosition = Attributes.defineBindableInt Entry.CursorPositionProperty
 
     let FontAttributes =
         Attributes.defineBindableEnum<FontAttributes> Entry.FontAttributesProperty
@@ -23,23 +22,19 @@ module Entry =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Entry.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Entry.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Entry.FontSizeProperty
 
     let HorizontalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> Entry.HorizontalTextAlignmentProperty
 
-    let IsPassword =
-        Attributes.defineBindableBool Entry.IsPasswordProperty
+    let IsPassword = Attributes.defineBindableBool Entry.IsPasswordProperty
 
     let IsTextPredictionEnabled =
         Attributes.defineBindableBool Entry.IsTextPredictionEnabledProperty
 
-    let ReturnType =
-        Attributes.defineBindableEnum<ReturnType> Entry.ReturnTypeProperty
+    let ReturnType = Attributes.defineBindableEnum<ReturnType> Entry.ReturnTypeProperty
 
-    let SelectionLength =
-        Attributes.defineBindableInt Entry.SelectionLengthProperty
+    let SelectionLength = Attributes.defineBindableInt Entry.SelectionLengthProperty
 
     let VerticalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> Entry.VerticalTextAlignmentProperty
@@ -48,28 +43,24 @@ module Entry =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
     let CursorColor =
-        Attributes.defineSmallScalar<FabColor>
-            "Entry_CursorColor"
-            SmallScalars.FabColor.decode
-            (fun _ newValueOpt node ->
-                let entry = node.Target :?> Entry
+        Attributes.defineSmallScalar<FabColor> "Entry_CursorColor" SmallScalars.FabColor.decode (fun _ newValueOpt node ->
+            let entry = node.Target :?> Entry
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> Color.Default
-                    | ValueSome x -> x.ToXFColor()
+            let value =
+                match newValueOpt with
+                | ValueNone -> Color.Default
+                | ValueSome x -> x.ToXFColor()
 
-                iOSSpecific.Entry.SetCursorColor(entry, value))
+            iOSSpecific.Entry.SetCursorColor(entry, value))
 
 [<AutoOpen>]
 module EntryBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IEntry>(
                 Entry.WidgetKey,
-                InputView.TextWithEvent.WithValue(
-                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
-                )
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
             )
 
 [<Extension>]
@@ -83,14 +74,7 @@ type EntryModifiers =
         this.AddScalar(Entry.CursorPosition.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IEntry>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IEntry>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/FormattedLabel.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/FormattedLabel.fs
@@ -11,19 +11,18 @@ module FormattedLabel =
     let WidgetKey = Widgets.register<Label>()
 
     let Spans =
-        Attributes.defineListWidgetCollection
-            "FormattedString_Spans"
-            (fun target ->
-                let label = target :?> Label
+        Attributes.defineListWidgetCollection "FormattedString_Spans" (fun target ->
+            let label = target :?> Label
 
-                if label.FormattedText = null then
-                    label.FormattedText <- FormattedString()
+            if label.FormattedText = null then
+                label.FormattedText <- FormattedString()
 
-                label.FormattedText.Spans)
+            label.FormattedText.Spans)
 
 [<AutoOpen>]
 module FormattedLabelBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline FormattedLabel<'msg>() =
             CollectionBuilder<'msg, IFormattedLabel, ISpan>(FormattedLabel.WidgetKey, FormattedLabel.Spans)
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -12,27 +12,21 @@ type IImage =
 module Image =
     let WidgetKey = Widgets.register<Image>()
 
-    let Aspect =
-        Attributes.defineBindableEnum<Aspect> Image.AspectProperty
+    let Aspect = Attributes.defineBindableEnum<Aspect> Image.AspectProperty
 
     let IsAnimationPlaying =
         Attributes.defineBindableBool Image.IsAnimationPlayingProperty
 
-    let IsOpaque =
-        Attributes.defineBindableBool Image.IsOpaqueProperty
+    let IsOpaque = Attributes.defineBindableBool Image.IsOpaqueProperty
 
-    let Source =
-        Attributes.defineBindableAppTheme<ImageSource> Image.SourceProperty
+    let Source = Attributes.defineBindableAppTheme<ImageSource> Image.SourceProperty
 
 [<AutoOpen>]
 module ImageBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Image<'msg>(aspect: Aspect, light: ImageSource, ?dark: ImageSource) =
-            WidgetBuilder<'msg, IImage>(
-                Image.WidgetKey,
-                Image.Aspect.WithValue(aspect),
-                Image.Source.WithValue(AppTheme.create light dark)
-            )
+            WidgetBuilder<'msg, IImage>(Image.WidgetKey, Image.Aspect.WithValue(aspect), Image.Source.WithValue(AppTheme.create light dark))
 
         static member inline Image<'msg>(aspect: Aspect, light: string, ?dark: string) =
             let light = ImageSource.FromFile(light)

--- a/src/Fabulous.XamarinForms/Views/Controls/ImageButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ImageButton.fs
@@ -18,20 +18,15 @@ module ImageButton =
     let BorderColor =
         Attributes.defineBindableAppThemeColor ImageButton.BorderColorProperty
 
-    let BorderWidth =
-        Attributes.defineBindableFloat ImageButton.BorderWidthProperty
+    let BorderWidth = Attributes.defineBindableFloat ImageButton.BorderWidthProperty
 
-    let CornerRadius =
-        Attributes.defineBindableFloat ImageButton.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableFloat ImageButton.CornerRadiusProperty
 
-    let IsLoading =
-        Attributes.defineBindableBool ImageButton.IsLoadingProperty
+    let IsLoading = Attributes.defineBindableBool ImageButton.IsLoadingProperty
 
-    let IsOpaque =
-        Attributes.defineBindableBool ImageButton.IsOpaqueProperty
+    let IsOpaque = Attributes.defineBindableBool ImageButton.IsOpaqueProperty
 
-    let IsPressed =
-        Attributes.defineBindableBool ImageButton.IsPressedProperty
+    let IsPressed = Attributes.defineBindableBool ImageButton.IsPressedProperty
 
     let Padding =
         Attributes.defineBindableWithEquality<Thickness> ImageButton.PaddingProperty
@@ -51,13 +46,8 @@ module ImageButton =
 [<AutoOpen>]
 module ImageButtonBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline ImageButton<'msg>
-            (
-                aspect: Aspect,
-                light: ImageSource,
-                onClicked: 'msg,
-                ?dark: ImageSource
-            ) =
+
+        static member inline ImageButton<'msg>(aspect: Aspect, light: ImageSource, onClicked: 'msg, ?dark: ImageSource) =
             WidgetBuilder<'msg, IImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Aspect.WithValue(aspect),
@@ -137,14 +127,7 @@ type ImageButtonModifiers =
         ImageButtonModifiers.padding(this, Thickness(value))
 
     [<Extension>]
-    static member inline padding
-        (
-            this: WidgetBuilder<'msg, #IImageButton>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline padding(this: WidgetBuilder<'msg, #IImageButton>, left: float, top: float, right: float, bottom: float) =
         ImageButtonModifiers.padding(this, Thickness(left, top, right, bottom))
 
     /// <summary>Event that is fired when image button is pressed.</summary>

--- a/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
@@ -20,8 +20,7 @@ module IndicatorView =
                 })
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
 
-    let HideSingle =
-        Attributes.defineBindableBool IndicatorView.HideSingleProperty
+    let HideSingle = Attributes.defineBindableBool IndicatorView.HideSingleProperty
 
     let IndicatorColor =
         Attributes.defineBindableAppThemeColor IndicatorView.IndicatorColorProperty
@@ -41,11 +40,9 @@ module IndicatorView =
 [<AutoOpen>]
 module IndicatorViewBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline IndicatorView<'msg>(reference: ViewRef<IndicatorView>) =
-            WidgetBuilder<'msg, IIndicatorView>(
-                IndicatorView.WidgetKey,
-                ViewRefAttributes.ViewRef.WithValue(reference.Unbox)
-            )
+            WidgetBuilder<'msg, IIndicatorView>(IndicatorView.WidgetKey, ViewRefAttributes.ViewRef.WithValue(reference.Unbox))
 
 [<Extension>]
 type IndicatorViewModifiers =
@@ -53,12 +50,7 @@ type IndicatorViewModifiers =
     /// <param name="light">The color of the indicator in the light theme.</param>
     /// <param name="dark">The color of the indicator in the dark theme.</param>
     [<Extension>]
-    static member inline selectedIndicatorColor
-        (
-            this: WidgetBuilder<'msg, #IIndicatorView>,
-            light: FabColor,
-            ?dark: FabColor
-        ) =
+    static member inline selectedIndicatorColor(this: WidgetBuilder<'msg, #IIndicatorView>, light: FabColor, ?dark: FabColor) =
         this.AddScalar(IndicatorView.SelectedIndicatorColor.WithValue(AppTheme.create light dark))
 
     /// <summary>Sets the indicator size.</summary>

--- a/src/Fabulous.XamarinForms/Views/Controls/Label.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Label.fs
@@ -10,8 +10,7 @@ type ILabel =
 module Label =
     let WidgetKey = Widgets.register<Label>()
 
-    let CharacterSpacing =
-        Attributes.defineBindableFloat Label.CharacterSpacingProperty
+    let CharacterSpacing = Attributes.defineBindableFloat Label.CharacterSpacingProperty
 
     let FontAttributes =
         Attributes.defineBindableEnum<Xamarin.Forms.FontAttributes> Label.FontAttributesProperty
@@ -19,8 +18,7 @@ module Label =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Label.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Label.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Label.FontSizeProperty
 
     let HorizontalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> Label.HorizontalTextAlignmentProperty
@@ -28,29 +26,23 @@ module Label =
     let LineBreakMode =
         Attributes.defineBindableEnum<Xamarin.Forms.LineBreakMode> Label.LineBreakModeProperty
 
-    let LineHeight =
-        Attributes.defineBindableFloat Label.LineHeightProperty
+    let LineHeight = Attributes.defineBindableFloat Label.LineHeightProperty
 
-    let MaxLines =
-        Attributes.defineBindableInt Label.MaxLinesProperty
+    let MaxLines = Attributes.defineBindableInt Label.MaxLinesProperty
 
-    let Padding =
-        Attributes.defineBindableWithEquality<Thickness> Label.PaddingProperty
+    let Padding = Attributes.defineBindableWithEquality<Thickness> Label.PaddingProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor Label.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor Label.TextColorProperty
 
     let TextDecorations =
         Attributes.defineBindableEnum<TextDecorations> Label.TextDecorationsProperty
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> Label.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> Label.TextProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> Label.TextTransformProperty
 
-    let TextType =
-        Attributes.defineBindableEnum<TextType> Label.TextTypeProperty
+    let TextType = Attributes.defineBindableEnum<TextType> Label.TextTypeProperty
 
     let VerticalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> Label.VerticalTextAlignmentProperty
@@ -59,6 +51,7 @@ module Label =
 [<AutoOpen>]
 module LabelBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Label<'msg>(text: string) =
             WidgetBuilder<'msg, ILabel>(Label.WidgetKey, Label.Text.WithValue(text))
 
@@ -70,14 +63,7 @@ type LabelModifiers =
         this.AddScalar(Label.CharacterSpacing.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #ILabel>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #ILabel>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 
@@ -124,14 +110,7 @@ type LabelModifiers =
         LabelModifiers.padding(this, Thickness(value))
 
     [<Extension>]
-    static member inline padding
-        (
-            this: WidgetBuilder<'msg, #ILabel>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline padding(this: WidgetBuilder<'msg, #ILabel>, left: float, top: float, right: float, bottom: float) =
         LabelModifiers.padding(this, Thickness(left, top, right, bottom))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -26,62 +26,49 @@ module Picker =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Picker.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Picker.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Picker.FontSizeProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor Picker.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor Picker.TextColorProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> Picker.TextTransformProperty
 
-    let Title =
-        Attributes.defineBindableWithEquality<string> Picker.TitleProperty
+    let Title = Attributes.defineBindableWithEquality<string> Picker.TitleProperty
 
-    let TitleColor =
-        Attributes.defineBindableAppThemeColor Picker.TitleColorProperty
+    let TitleColor = Attributes.defineBindableAppThemeColor Picker.TitleColorProperty
 
     let ItemsSource =
-        Attributes.defineSimpleScalarWithEquality<string array>
-            "Picker_ItemSource"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string array> "Picker_ItemSource" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Picker.ItemsSourceProperty)
-                | ValueSome value -> target.SetValue(Picker.ItemsSourceProperty, value))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Picker.ItemsSourceProperty)
+            | ValueSome value -> target.SetValue(Picker.ItemsSourceProperty, value))
 
     let SelectedIndexWithEvent =
-        Attributes.defineBindableWithEvent
-            "Picker_SelectedIndexChanged"
-            Picker.SelectedIndexProperty
-            (fun target ->
-                (target :?> CustomPicker)
-                    .CustomSelectedIndexChanged)
+        Attributes.defineBindableWithEvent "Picker_SelectedIndexChanged" Picker.SelectedIndexProperty (fun target ->
+            (target :?> CustomPicker).CustomSelectedIndexChanged)
 
     let UpdateMode =
-        Attributes.defineEnum<iOSSpecific.UpdateMode>
-            "Picker_UpdateMode"
-            (fun _ newValueOpt node ->
-                let picker = node.Target :?> Picker
+        Attributes.defineEnum<iOSSpecific.UpdateMode> "Picker_UpdateMode" (fun _ newValueOpt node ->
+            let picker = node.Target :?> Picker
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                | ValueSome v -> v
 
-                iOSSpecific.Picker.SetUpdateMode(picker, value))
+            iOSSpecific.Picker.SetUpdateMode(picker, value))
 
 [<AutoOpen>]
 module PickerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Picker<'msg>(items: string list, selectedIndex: int, onSelectedIndexChanged: int -> 'msg) =
             WidgetBuilder<'msg, IPicker>(
                 Picker.WidgetKey,
                 Picker.ItemsSource.WithValue(Array.ofList items),
-                Picker.SelectedIndexWithEvent.WithValue(
-                    ValueEventData.create selectedIndex (fun args -> onSelectedIndexChanged args.CurrentPosition |> box)
-                )
+                Picker.SelectedIndexWithEvent.WithValue(ValueEventData.create selectedIndex (fun args -> onSelectedIndexChanged args.CurrentPosition |> box))
             )
 
 [<Extension>]
@@ -99,14 +86,7 @@ type PickerModifiers =
         this.AddScalar(Picker.VerticalTextAlignment.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IPicker>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IPicker>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/ProgressBar.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ProgressBar.fs
@@ -21,26 +21,20 @@ module ProgressBar =
     let ProgressColor =
         Attributes.defineBindableAppThemeColor ProgressBar.ProgressColorProperty
 
-    let Progress =
-        Attributes.defineBindableFloat ProgressBar.ProgressProperty
+    let Progress = Attributes.defineBindableFloat ProgressBar.ProgressProperty
 
     let ProgressTo =
-        Attributes.defineSimpleScalarWithEquality<ProgressToData>
-            "ProgressBar_ProgressTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> ProgressBar
+        Attributes.defineSimpleScalarWithEquality<ProgressToData> "ProgressBar_ProgressTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> ProgressBar
 
-                match newValueOpt with
-                | ValueNone ->
-                    view.ProgressTo(0., uint32 0, Easing.Linear)
-                    |> ignore
-                | ValueSome data ->
-                    view.ProgressTo(data.Progress, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.ProgressTo(0., uint32 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ProgressTo(data.Progress, data.AnimationDuration, data.Easing) |> ignore)
 
 [<AutoOpen>]
 module ProgressBarBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ProgressBar<'msg>(progress: float) =
             WidgetBuilder<'msg, IProgressBar>(ProgressBar.WidgetKey, ProgressBar.Progress.WithValue(progress))
 

--- a/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
@@ -17,20 +17,17 @@ module RadioButton =
     let GroupName =
         Attributes.defineBindableWithEquality<string> RadioButton.GroupNameProperty
 
-    let BorderWidth =
-        Attributes.defineBindableFloat RadioButton.BorderWidthProperty
+    let BorderWidth = Attributes.defineBindableFloat RadioButton.BorderWidthProperty
 
     let CharacterSpacing =
         Attributes.defineBindableFloat RadioButton.CharacterSpacingProperty
 
-    let CornerRadius =
-        Attributes.defineBindableFloat RadioButton.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableFloat RadioButton.CornerRadiusProperty
 
     let ContentString =
         Attributes.defineBindableWithEquality<string> RadioButton.ContentProperty
 
-    let ContentWidget =
-        Attributes.defineBindableWidget RadioButton.ContentProperty
+    let ContentWidget = Attributes.defineBindableWidget RadioButton.ContentProperty
 
     let FontAttributes =
         Attributes.defineBindableEnum<FontAttributes> RadioButton.FontAttributesProperty
@@ -38,11 +35,9 @@ module RadioButton =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> RadioButton.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat RadioButton.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat RadioButton.FontSizeProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor RadioButton.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor RadioButton.TextColorProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> RadioButton.TextTransformProperty
@@ -51,38 +46,25 @@ module RadioButton =
         Attributes.defineBindableWithEquality<string> RadioButtonGroup.GroupNameProperty
 
     let IsCheckedWithEvent =
-        Attributes.defineBindableWithEvent
-            "RadioButton_CheckedChanged"
-            RadioButton.IsCheckedProperty
-            (fun target -> (target :?> RadioButton).CheckedChanged)
+        Attributes.defineBindableWithEvent "RadioButton_CheckedChanged" RadioButton.IsCheckedProperty (fun target -> (target :?> RadioButton).CheckedChanged)
 
 [<AutoOpen>]
 module RadioButtonBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline RadioButton<'msg>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IRadioButton>(
                 RadioButton.WidgetKey,
-                RadioButton.IsCheckedWithEvent.WithValue(
-                    ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)
-                ),
+                RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)),
                 RadioButton.ContentString.WithValue(content)
             )
 
-        static member inline RadioButton<'msg, 'marker when 'marker :> IView>
-            (
-                content: WidgetBuilder<'msg, 'marker>,
-                isChecked: bool,
-                onChecked: bool -> 'msg
-            ) =
+        static member inline RadioButton<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IRadioButton>(
                 RadioButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(
-                        RadioButton.IsCheckedWithEvent.WithValue(
-                            ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)
-                        )
-                    ),
+                    StackList.one(RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onChecked args.Value |> box))),
                     ValueSome [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )
@@ -121,14 +103,7 @@ type RadioButtonModifiers =
         this.AddScalar(RadioButton.CornerRadius.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #IRadioButton>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #IRadioButton>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
@@ -19,8 +19,7 @@ module SearchBar =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> SearchBar.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat SearchBar.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat SearchBar.FontSizeProperty
 
     let HorizontalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> SearchBar.HorizontalTextAlignmentProperty
@@ -29,19 +28,16 @@ module SearchBar =
         Attributes.defineBindableEnum<TextAlignment> SearchBar.VerticalTextAlignmentProperty
 
     let SearchButtonPressed =
-        Attributes.defineEventNoArg
-            "SearchBar_SearchButtonPressed"
-            (fun target -> (target :?> SearchBar).SearchButtonPressed)
+        Attributes.defineEventNoArg "SearchBar_SearchButtonPressed" (fun target -> (target :?> SearchBar).SearchButtonPressed)
 
 [<AutoOpen>]
 module SearchBarBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
             WidgetBuilder<'msg, ISearchBar>(
                 SearchBar.WidgetKey,
-                InputView.TextWithEvent.WithValue(
-                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
-                ),
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)),
                 SearchBar.SearchButtonPressed.WithValue(onSearchButtonPressed)
             )
 
@@ -55,14 +51,7 @@ type SearchBarModifiers =
         this.AddScalar(SearchBar.CancelButtonColor.WithValue(AppTheme.create light dark))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #ISearchBar>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #ISearchBar>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
@@ -17,9 +17,8 @@ module SliderUpdaters =
         | ValueNone ->
             slider.ClearValue(Slider.MinimumProperty)
             slider.ClearValue(Slider.MaximumProperty)
-        | ValueSome (min, max) ->
-            let currMax =
-                slider.GetValue(Slider.MaximumProperty) :?> float
+        | ValueSome(min, max) ->
+            let currMax = slider.GetValue(Slider.MaximumProperty) :?> float
 
             if min > currMax then
                 slider.SetValue(Slider.MaximumProperty, max)
@@ -32,9 +31,7 @@ module Slider =
     let WidgetKey = Widgets.register<Slider>()
 
     let MinimumMaximum =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "Slider_MinimumMaximum"
-            SliderUpdaters.updateSliderMinMax
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "Slider_MinimumMaximum" SliderUpdaters.updateSliderMinMax
 
     let MaximumTrackColor =
         Attributes.defineBindableAppThemeColor Slider.MaximumTrackColorProperty
@@ -42,17 +39,13 @@ module Slider =
     let MinimumTrackColor =
         Attributes.defineBindableAppThemeColor Slider.MinimumTrackColorProperty
 
-    let ThumbColor =
-        Attributes.defineBindableAppThemeColor Slider.ThumbColorProperty
+    let ThumbColor = Attributes.defineBindableAppThemeColor Slider.ThumbColorProperty
 
     let ThumbImageSource =
         Attributes.defineBindableAppTheme<ImageSource> Slider.ThumbImageSourceProperty
 
     let ValueWithEvent =
-        Attributes.defineBindableWithEvent
-            "Slider_ValueWithEvent"
-            Slider.ValueProperty
-            (fun target -> (target :?> Slider).ValueChanged)
+        Attributes.defineBindableWithEvent "Slider_ValueWithEvent" Slider.ValueProperty (fun target -> (target :?> Slider).ValueChanged)
 
     let DragCompleted =
         Attributes.defineEventNoArg "Slider_DragCompleted" (fun target -> (target :?> Slider).DragCompleted)
@@ -63,13 +56,12 @@ module Slider =
 [<AutoOpen>]
 module SliderBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, ISlider>(
                 Slider.WidgetKey,
                 Slider.MinimumMaximum.WithValue(struct (min, max)),
-                Slider.ValueWithEvent.WithValue(
-                    ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box)
-                )
+                Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box))
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Span.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Span.fs
@@ -13,8 +13,7 @@ module Span =
     let BackgroundColor =
         Attributes.defineBindableAppThemeColor Span.BackgroundColorProperty
 
-    let CharacterSpacing =
-        Attributes.defineBindableFloat Span.CharacterSpacingProperty
+    let CharacterSpacing = Attributes.defineBindableFloat Span.CharacterSpacingProperty
 
     let FontAttributes =
         Attributes.defineBindableEnum<FontAttributes> Span.FontAttributesProperty
@@ -22,17 +21,13 @@ module Span =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> Span.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat Span.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat Span.FontSizeProperty
 
-    let LineHeight =
-        Attributes.defineBindableFloat Span.LineHeightProperty
+    let LineHeight = Attributes.defineBindableFloat Span.LineHeightProperty
 
-    let Style =
-        Attributes.defineBindableWithEquality<Style> Span.StyleProperty
+    let Style = Attributes.defineBindableWithEquality<Style> Span.StyleProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor Span.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor Span.TextColorProperty
 
     let TextDecorations =
         Attributes.defineBindableEnum<TextDecorations> Span.TextDecorationsProperty
@@ -40,17 +35,15 @@ module Span =
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> Span.TextTransformProperty
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> Span.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> Span.TextProperty
 
     let GestureRecognizers =
-        Attributes.defineListWidgetCollection<IGestureRecognizer>
-            "Span_GestureRecognizers"
-            (fun target -> (target :?> Span).GestureRecognizers)
+        Attributes.defineListWidgetCollection<IGestureRecognizer> "Span_GestureRecognizers" (fun target -> (target :?> Span).GestureRecognizers)
 
 [<AutoOpen>]
 module SpanBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Span<'msg>(text: string) =
             WidgetBuilder<'msg, ISpan>(Span.WidgetKey, Span.Text.WithValue(text))
 
@@ -66,14 +59,7 @@ type SpanModifiers =
         this.AddScalar(Span.CharacterSpacing.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #ISpan>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #ISpan>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 
@@ -117,9 +103,7 @@ type SpanModifiers =
 
     [<Extension>]
     static member inline gestureRecognizers<'msg, 'marker when 'marker :> ISpan>(this: WidgetBuilder<'msg, 'marker>) =
-        WidgetHelpers.buildAttributeCollection<'msg, 'marker, Fabulous.XamarinForms.IGestureRecognizer>
-            Span.GestureRecognizers
-            this
+        WidgetHelpers.buildAttributeCollection<'msg, 'marker, Fabulous.XamarinForms.IGestureRecognizer> Span.GestureRecognizers this
 
     /// <summary>Link a ViewRef to access the direct Span control instance</summary>
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
@@ -15,9 +15,8 @@ module StepperUpdaters =
         | ValueNone ->
             stepper.ClearValue(Stepper.MinimumProperty)
             stepper.ClearValue(Stepper.MaximumProperty)
-        | ValueSome (min, max) ->
-            let currMax =
-                stepper.GetValue(Stepper.MaximumProperty) :?> float
+        | ValueSome(min, max) ->
+            let currMax = stepper.GetValue(Stepper.MaximumProperty) :?> float
 
             if min > currMax then
                 stepper.SetValue(Stepper.MaximumProperty, max)
@@ -29,30 +28,23 @@ module StepperUpdaters =
 module Stepper =
     let WidgetKey = Widgets.register<Stepper>()
 
-    let Increment =
-        Attributes.defineBindableFloat Stepper.IncrementProperty
+    let Increment = Attributes.defineBindableFloat Stepper.IncrementProperty
 
     let MinimumMaximum =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "Stepper_MinimumMaximum"
-            StepperUpdaters.updateStepperMinMax
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "Stepper_MinimumMaximum" StepperUpdaters.updateStepperMinMax
 
     let ValueWithEvent =
-        Attributes.defineBindableWithEvent
-            "Stepper_ValueChanged"
-            Stepper.ValueProperty
-            (fun target -> (target :?> Stepper).ValueChanged)
+        Attributes.defineBindableWithEvent "Stepper_ValueChanged" Stepper.ValueProperty (fun target -> (target :?> Stepper).ValueChanged)
 
 [<AutoOpen>]
 module StepperBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Stepper<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, IStepper>(
                 Stepper.WidgetKey,
                 Stepper.MinimumMaximum.WithValue(struct (min, max)),
-                Stepper.ValueWithEvent.WithValue(
-                    ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box)
-                )
+                Stepper.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box))
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
@@ -10,27 +10,21 @@ type ISwitch =
 module Switch =
     let WidgetKey = Widgets.register<Switch>()
 
-    let ColorOn =
-        Attributes.defineBindableAppThemeColor Switch.OnColorProperty
+    let ColorOn = Attributes.defineBindableAppThemeColor Switch.OnColorProperty
 
-    let ThumbColor =
-        Attributes.defineBindableAppThemeColor Switch.ThumbColorProperty
+    let ThumbColor = Attributes.defineBindableAppThemeColor Switch.ThumbColorProperty
 
     let IsToggledWithEvent =
-        Attributes.defineBindableWithEvent
-            "Switch_Toggled"
-            Switch.IsToggledProperty
-            (fun target -> (target :?> Switch).Toggled)
+        Attributes.defineBindableWithEvent "Switch_Toggled" Switch.IsToggledProperty (fun target -> (target :?> Switch).Toggled)
 
 [<AutoOpen>]
 module SwitchBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
             WidgetBuilder<'msg, ISwitch>(
                 Switch.WidgetKey,
-                Switch.IsToggledWithEvent.WithValue(
-                    ValueEventData.create isToggled (fun args -> onToggled args.Value |> box)
-                )
+                Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun args -> onToggled args.Value |> box))
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
@@ -15,10 +15,7 @@ module TimePicker =
         Attributes.defineBindableFloat TimePicker.CharacterSpacingProperty
 
     let TimeWithEvent =
-        Attributes.defineBindableWithEvent
-            "TimePicker_TimeSelected"
-            TimePicker.TimeProperty
-            (fun target -> (target :?> FabulousTimePicker).TimeSelected)
+        Attributes.defineBindableWithEvent "TimePicker_TimeSelected" TimePicker.TimeProperty (fun target -> (target :?> FabulousTimePicker).TimeSelected)
 
     let FontAttributes =
         Attributes.defineBindableEnum<FontAttributes> TimePicker.FontAttributesProperty
@@ -26,40 +23,34 @@ module TimePicker =
     let FontFamily =
         Attributes.defineBindableWithEquality<string> TimePicker.FontFamilyProperty
 
-    let FontSize =
-        Attributes.defineBindableFloat TimePicker.FontSizeProperty
+    let FontSize = Attributes.defineBindableFloat TimePicker.FontSizeProperty
 
-    let Format =
-        Attributes.defineBindableWithEquality<string> TimePicker.FormatProperty
+    let Format = Attributes.defineBindableWithEquality<string> TimePicker.FormatProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor TimePicker.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor TimePicker.TextColorProperty
 
     let TextTransform =
         Attributes.defineBindableEnum<TextTransform> TimePicker.TextTransformProperty
 
     let UpdateMode =
-        Attributes.defineEnum<iOSSpecific.UpdateMode>
-            "TimePicker_UpdateMode"
-            (fun _ newValueOpt node ->
-                let timePicker = node.Target :?> TimePicker
+        Attributes.defineEnum<iOSSpecific.UpdateMode> "TimePicker_UpdateMode" (fun _ newValueOpt node ->
+            let timePicker = node.Target :?> TimePicker
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                | ValueSome v -> v
 
-                iOSSpecific.TimePicker.SetUpdateMode(timePicker, value))
+            iOSSpecific.TimePicker.SetUpdateMode(timePicker, value))
 
 [<AutoOpen>]
 module TimePickerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline TimePicker<'msg>(time: System.TimeSpan, onTimeSelected: System.TimeSpan -> 'msg) =
             WidgetBuilder<'msg, ITimePicker>(
                 TimePicker.WidgetKey,
-                TimePicker.TimeWithEvent.WithValue(
-                    ValueEventData.create time (fun args -> onTimeSelected args.NewTime |> box)
-                )
+                TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun args -> onTimeSelected args.NewTime |> box))
             )
 
 [<Extension>]
@@ -81,14 +72,7 @@ type TimePickerModifiers =
         this.AddScalar(TimePicker.TextTransform.WithValue(value))
 
     [<Extension>]
-    static member inline font
-        (
-            this: WidgetBuilder<'msg, #ITimePicker>,
-            ?size: float,
-            ?namedSize: NamedSize,
-            ?attributes: FontAttributes,
-            ?fontFamily: string
-        ) =
+    static member inline font(this: WidgetBuilder<'msg, #ITimePicker>, ?size: float, ?namedSize: NamedSize, ?attributes: FontAttributes, ?fontFamily: string) =
 
         let mutable res = this
 

--- a/src/Fabulous.XamarinForms/Views/Controls/WebView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/WebView.fs
@@ -14,11 +14,9 @@ module WebView =
 
     let WidgetKey = Widgets.register<WebView>()
 
-    let CanGoBack =
-        Attributes.defineBindableBool WebView.CanGoBackProperty
+    let CanGoBack = Attributes.defineBindableBool WebView.CanGoBackProperty
 
-    let CanGoForward =
-        Attributes.defineBindableBool WebView.CanGoForwardProperty
+    let CanGoForward = Attributes.defineBindableBool WebView.CanGoForwardProperty
 
     let Source =
         Attributes.defineBindableWithEquality<WebViewSource> WebView.SourceProperty
@@ -27,9 +25,7 @@ module WebView =
         Attributes.defineBindableWithEquality<CookieContainer> WebView.CookiesProperty
 
     let Navigating =
-        Attributes.defineEvent<WebNavigatingEventArgs>
-            "WebView_Navigating"
-            (fun target -> (target :?> WebView).Navigating)
+        Attributes.defineEvent<WebNavigatingEventArgs> "WebView_Navigating" (fun target -> (target :?> WebView).Navigating)
 
     let Navigated =
         Attributes.defineEvent<WebNavigatedEventArgs> "WebView_Navigated" (fun target -> (target :?> WebView).Navigated)
@@ -38,34 +34,31 @@ module WebView =
         Attributes.defineEventNoArg "WebView_ReloadRequested" (fun target -> (target :?> WebView).ReloadRequested)
 
     let EnableZoomControls =
-        Attributes.defineBool
-            "WebView_EnableZoomControls"
-            (fun _ newValueOpt node ->
-                let webview = node.Target :?> WebView
+        Attributes.defineBool "WebView_EnableZoomControls" (fun _ newValueOpt node ->
+            let webview = node.Target :?> WebView
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                AndroidSpecific.WebView.SetEnableZoomControls(webview, value))
+            AndroidSpecific.WebView.SetEnableZoomControls(webview, value))
 
     let DisplayZoomControls =
-        Attributes.defineBool
-            "WebView_DisplayZoomControls"
-            (fun _ newValueOpt node ->
-                let webview = node.Target :?> WebView
+        Attributes.defineBool "WebView_DisplayZoomControls" (fun _ newValueOpt node ->
+            let webview = node.Target :?> WebView
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                AndroidSpecific.WebView.SetDisplayZoomControls(webview, value))
+            AndroidSpecific.WebView.SetDisplayZoomControls(webview, value))
 
 [<AutoOpen>]
 module WebViewBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline WebView<'msg>(source: WebViewSource) =
             WidgetBuilder<'msg, IWebView>(WebView.WidgetKey, WebView.Source.WithValue(source))
 
@@ -106,11 +99,7 @@ type WebViewModifiers() =
         this.AddScalar(WebView.Cookies.WithValue(value))
 
     [<Extension>]
-    static member inline onNavigating
-        (
-            this: WidgetBuilder<'msg, #IWebView>,
-            onNavigating: WebNavigatingEventArgs -> 'msg
-        ) =
+    static member inline onNavigating(this: WidgetBuilder<'msg, #IWebView>, onNavigating: WebNavigatingEventArgs -> 'msg) =
         this.AddScalar(WebView.Navigating.WithValue(fun args -> onNavigating args |> box))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
@@ -12,14 +12,12 @@ module InputView =
     let CharacterSpacing =
         Attributes.defineBindableFloat InputView.CharacterSpacingProperty
 
-    let IsReadOnly =
-        Attributes.defineBindableBool InputView.IsReadOnlyProperty
+    let IsReadOnly = Attributes.defineBindableBool InputView.IsReadOnlyProperty
 
     let IsSpellCheckEnabled =
         Attributes.defineBindableBool InputView.IsSpellCheckEnabledProperty
 
-    let MaxLength =
-        Attributes.defineBindableInt InputView.MaxLengthProperty
+    let MaxLength = Attributes.defineBindableInt InputView.MaxLengthProperty
 
     let Placeholder =
         Attributes.defineBindableWithEquality<string> InputView.PlaceholderProperty
@@ -27,8 +25,7 @@ module InputView =
     let PlaceholderColor =
         Attributes.defineBindableAppThemeColor InputView.PlaceholderColorProperty
 
-    let TextColor =
-        Attributes.defineBindableAppThemeColor InputView.TextColorProperty
+    let TextColor = Attributes.defineBindableAppThemeColor InputView.TextColorProperty
 
     let Keyboard =
         Attributes.defineBindableWithEquality<Keyboard> InputView.KeyboardProperty
@@ -37,10 +34,8 @@ module InputView =
         Attributes.defineBindableEnum<TextTransform> InputView.TextTransformProperty
 
     let TextWithEvent =
-        Attributes.defineBindableWithEvent<string, TextChangedEventArgs>
-            "InputView_TextChanged"
-            InputView.TextProperty
-            (fun target -> (target :?> InputView).TextChanged)
+        Attributes.defineBindableWithEvent<string, TextChangedEventArgs> "InputView_TextChanged" InputView.TextProperty (fun target ->
+            (target :?> InputView).TextChanged)
 
 [<Extension>]
 type InputViewModifiers =

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/DragGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/DragGestureRecognizer.fs
@@ -8,26 +8,21 @@ type IDragGestureRecognizer =
     inherit Fabulous.XamarinForms.IGestureRecognizer
 
 module DragGestureRecognizer =
-    let WidgetKey =
-        Widgets.register<DragGestureRecognizer>()
+    let WidgetKey = Widgets.register<DragGestureRecognizer>()
 
-    let CanDrag =
-        Attributes.defineBindableBool DragGestureRecognizer.CanDragProperty
+    let CanDrag = Attributes.defineBindableBool DragGestureRecognizer.CanDragProperty
 
     let DragStarting =
-        Attributes.defineEvent<DragStartingEventArgs>
-            "DragGestureRecognizer_DragStarting"
-            (fun target -> (target :?> DragGestureRecognizer).DragStarting)
+        Attributes.defineEvent<DragStartingEventArgs> "DragGestureRecognizer_DragStarting" (fun target -> (target :?> DragGestureRecognizer).DragStarting)
 
     let DropCompleted =
-        Attributes.defineEvent<DropCompletedEventArgs>
-            "DragGestureRecognizer_DropCompleted"
-            (fun target -> (target :?> DragGestureRecognizer).DropCompleted)
+        Attributes.defineEvent<DropCompletedEventArgs> "DragGestureRecognizer_DropCompleted" (fun target -> (target :?> DragGestureRecognizer).DropCompleted)
 
 
 [<AutoOpen>]
 module DragGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline DragGestureRecognizer<'msg>(onDragStarting: DragStartingEventArgs -> 'msg) =
             WidgetBuilder<'msg, IDragGestureRecognizer>(
                 DragGestureRecognizer.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/DropGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/DropGestureRecognizer.fs
@@ -8,35 +8,26 @@ type IDropGestureRecognizer =
     inherit Fabulous.XamarinForms.IGestureRecognizer
 
 module DropGestureRecognizer =
-    let WidgetKey =
-        Widgets.register<DropGestureRecognizer>()
+    let WidgetKey = Widgets.register<DropGestureRecognizer>()
 
     let AllowDrop =
         Attributes.defineBindableBool DropGestureRecognizer.AllowDropProperty
 
     let Drop =
-        Attributes.defineEvent<DropEventArgs>
-            "DropGestureRecognizer_Drop"
-            (fun target -> (target :?> DropGestureRecognizer).Drop)
+        Attributes.defineEvent<DropEventArgs> "DropGestureRecognizer_Drop" (fun target -> (target :?> DropGestureRecognizer).Drop)
 
     let DragOver =
-        Attributes.defineEvent<DragEventArgs>
-            "DropGestureRecognizer_DragOver"
-            (fun target -> (target :?> DropGestureRecognizer).DragOver)
+        Attributes.defineEvent<DragEventArgs> "DropGestureRecognizer_DragOver" (fun target -> (target :?> DropGestureRecognizer).DragOver)
 
     let DragLeave =
-        Attributes.defineEvent<DragEventArgs>
-            "DropGestureRecognizer_DragLeave"
-            (fun target -> (target :?> DropGestureRecognizer).DragLeave)
+        Attributes.defineEvent<DragEventArgs> "DropGestureRecognizer_DragLeave" (fun target -> (target :?> DropGestureRecognizer).DragLeave)
 
 [<AutoOpen>]
 module DropGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline DropGestureRecognizer<'msg>(onDrop: DropEventArgs -> 'msg) =
-            WidgetBuilder<'msg, IDropGestureRecognizer>(
-                DropGestureRecognizer.WidgetKey,
-                DropGestureRecognizer.Drop.WithValue(fun args -> onDrop args |> box)
-            )
+            WidgetBuilder<'msg, IDropGestureRecognizer>(DropGestureRecognizer.WidgetKey, DropGestureRecognizer.Drop.WithValue(fun args -> onDrop args |> box))
 
 [<Extension>]
 type DropGestureRecognizerModifiers =
@@ -48,17 +39,9 @@ type DropGestureRecognizerModifiers =
         this.AddScalar(DropGestureRecognizer.AllowDrop.WithValue(value))
 
     [<Extension>]
-    static member inline onDragOver
-        (
-            this: WidgetBuilder<'msg, #IDropGestureRecognizer>,
-            onDragOver: DragEventArgs -> 'msg
-        ) =
+    static member inline onDragOver(this: WidgetBuilder<'msg, #IDropGestureRecognizer>, onDragOver: DragEventArgs -> 'msg) =
         this.AddScalar(DropGestureRecognizer.DragOver.WithValue(fun args -> onDragOver args |> box))
 
     [<Extension>]
-    static member inline onDragLeave
-        (
-            this: WidgetBuilder<'msg, #IDropGestureRecognizer>,
-            onDragLeave: DragEventArgs -> 'msg
-        ) =
+    static member inline onDragLeave(this: WidgetBuilder<'msg, #IDropGestureRecognizer>, onDragLeave: DragEventArgs -> 'msg) =
         this.AddScalar(DropGestureRecognizer.DragLeave.WithValue(fun args -> onDragLeave args |> box))

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
@@ -14,13 +14,12 @@ module PanGestureRecognizer =
         Attributes.defineBindableInt PanGestureRecognizer.TouchPointsProperty
 
     let PanUpdated =
-        Attributes.defineEvent<PanUpdatedEventArgs>
-            "PanGestureRecognizer_PanUpdated"
-            (fun target -> (target :?> PanGestureRecognizer).PanUpdated)
+        Attributes.defineEvent<PanUpdatedEventArgs> "PanGestureRecognizer_PanUpdated" (fun target -> (target :?> PanGestureRecognizer).PanUpdated)
 
 [<AutoOpen>]
 module PanGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline PanGestureRecognizer<'msg>(onPanUpdated: PanUpdatedEventArgs -> 'msg) =
             WidgetBuilder<'msg, IPanGestureRecognizer>(
                 PanGestureRecognizer.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/PinchGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/PinchGestureRecognizer.fs
@@ -7,17 +7,16 @@ type IPinchGestureRecognizer =
     inherit Fabulous.XamarinForms.IGestureRecognizer
 
 module PinchGestureRecognizer =
-    let WidgetKey =
-        Widgets.register<PinchGestureRecognizer>()
+    let WidgetKey = Widgets.register<PinchGestureRecognizer>()
 
     let PinchUpdated =
-        Attributes.defineEvent<PinchGestureUpdatedEventArgs>
-            "PinchGestureRecognizer_PinchUpdated"
-            (fun target -> (target :?> PinchGestureRecognizer).PinchUpdated)
+        Attributes.defineEvent<PinchGestureUpdatedEventArgs> "PinchGestureRecognizer_PinchUpdated" (fun target ->
+            (target :?> PinchGestureRecognizer).PinchUpdated)
 
 [<AutoOpen>]
 module PinchGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline PinchGestureRecognizer<'msg>(onPinchUpdated: PinchGestureUpdatedEventArgs -> 'msg) =
             WidgetBuilder<'msg, IPinchGestureRecognizer>(
                 PinchGestureRecognizer.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
@@ -8,8 +8,7 @@ type ISwipeGestureRecognizer =
     inherit Fabulous.XamarinForms.IGestureRecognizer
 
 module SwipeGestureRecognizer =
-    let WidgetKey =
-        Widgets.register<SwipeGestureRecognizer>()
+    let WidgetKey = Widgets.register<SwipeGestureRecognizer>()
 
     let Direction =
         Attributes.defineBindableEnum<SwipeDirection> SwipeGestureRecognizer.DirectionProperty
@@ -18,13 +17,12 @@ module SwipeGestureRecognizer =
         Attributes.defineBindableInt SwipeGestureRecognizer.ThresholdProperty
 
     let Swiped =
-        Attributes.defineEvent<SwipedEventArgs>
-            "SwipeGestureRecognizer_Swiped"
-            (fun target -> (target :?> SwipeGestureRecognizer).Swiped)
+        Attributes.defineEvent<SwipedEventArgs> "SwipeGestureRecognizer_Swiped" (fun target -> (target :?> SwipeGestureRecognizer).Swiped)
 
 [<AutoOpen>]
 module SwipeGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline SwipeGestureRecognizer<'msg>(onSwiped: SwipeDirection -> 'msg) =
             WidgetBuilder<'msg, ISwipeGestureRecognizer>(
                 SwipeGestureRecognizer.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
@@ -11,9 +11,7 @@ module TapGestureRecognizer =
     let WidgetKey = Widgets.register<TapGestureRecognizer>()
 
     let Tapped =
-        Attributes.defineEventNoArg
-            "TapGestureRecognizer_Tapped"
-            (fun target -> (target :?> TapGestureRecognizer).Tapped)
+        Attributes.defineEventNoArg "TapGestureRecognizer_Tapped" (fun target -> (target :?> TapGestureRecognizer).Tapped)
 
     let NumberOfTapsRequired =
         Attributes.defineBindableInt TapGestureRecognizer.NumberOfTapsRequiredProperty
@@ -21,11 +19,9 @@ module TapGestureRecognizer =
 [<AutoOpen>]
 module TapGestureRecognizerBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline TapGestureRecognizer<'msg>(onTapped: 'msg) =
-            WidgetBuilder<'msg, ITapGestureRecognizer>(
-                TapGestureRecognizer.WidgetKey,
-                TapGestureRecognizer.Tapped.WithValue(onTapped)
-            )
+            WidgetBuilder<'msg, ITapGestureRecognizer>(TapGestureRecognizer.WidgetKey, TapGestureRecognizer.Tapped.WithValue(onTapped))
 
 [<Extension>]
 type TapGestureRecognizerModifiers =

--- a/src/Fabulous.XamarinForms/Views/Layouts/AbsoluteLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/AbsoluteLayout.fs
@@ -20,6 +20,7 @@ module AbsoluteLayout =
 [<AutoOpen>]
 module AbsoluteLayoutBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline AbsoluteLayout<'msg>() =
             CollectionBuilder<'msg, IAbsoluteLayout, IView>(AbsoluteLayout.WidgetKey, LayoutOfView.Children)
 
@@ -38,14 +39,7 @@ type AbsoluteLayoutAttachedModifiers =
     /// <param name= "width">The width of the bounding rectangle.</param>
     /// <param name= "height">The height of the bounding rectangle.</param>
     [<Extension>]
-    static member inline layoutBounds
-        (
-            this: WidgetBuilder<'msg, #IView>,
-            x: float,
-            y: float,
-            width: float,
-            height: float
-        ) =
+    static member inline layoutBounds(this: WidgetBuilder<'msg, #IView>, x: float, y: float, width: float, height: float) =
         this.AddScalar(AbsoluteLayout.LayoutBounds.WithValue(Rectangle(x, y, width, height)))
 
     /// <summary>Determines how the values in the list are interpreted to create the bounding rectangle.</summary>

--- a/src/Fabulous.XamarinForms/Views/Layouts/ContentView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ContentView.fs
@@ -10,16 +10,14 @@ type IContentView =
 module ContentView =
     let WidgetKey = Widgets.register<ContentView>()
 
-    let Content =
-        Attributes.defineBindableWidget ContentView.ContentProperty
+    let Content = Attributes.defineBindableWidget ContentView.ContentProperty
 
 [<AutoOpen>]
 module ContentViewBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ContentView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-            WidgetHelpers.buildWidgets<'msg, IContentView>
-                ContentView.WidgetKey
-                [| ContentView.Content.WithValue(content.Compile()) |]
+            WidgetHelpers.buildWidgets<'msg, IContentView> ContentView.WidgetKey [| ContentView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]
 type ContentViewModifiers =

--- a/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
@@ -28,37 +28,29 @@ module FlexLayout =
     let Direction =
         Attributes.defineBindableEnum<FlexDirection> FlexLayout.DirectionProperty
 
-    let Grow =
-        Attributes.defineBindableFloat FlexLayout.GrowProperty
+    let Grow = Attributes.defineBindableFloat FlexLayout.GrowProperty
 
     let JustifyContent =
         Attributes.defineBindableEnum<FlexJustify> FlexLayout.JustifyContentProperty
 
-    let Order =
-        Attributes.defineBindableInt FlexLayout.OrderProperty
+    let Order = Attributes.defineBindableInt FlexLayout.OrderProperty
 
     let Position =
         Attributes.defineBindableEnum<FlexPosition> FlexLayout.PositionProperty
 
-    let Shrink =
-        Attributes.defineBindableFloat FlexLayout.ShrinkProperty
+    let Shrink = Attributes.defineBindableFloat FlexLayout.ShrinkProperty
 
-    let Wrap =
-        Attributes.defineBindableEnum<FlexWrap> FlexLayout.WrapProperty
+    let Wrap = Attributes.defineBindableEnum<FlexWrap> FlexLayout.WrapProperty
 
 [<AutoOpen>]
 module FlexLayoutBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline FlexLayout<'msg>(?wrap: FlexWrap) =
             match wrap with
             | None -> CollectionBuilder<'msg, IFlexLayout, IView>(FlexLayout.WidgetKey, LayoutOfView.Children)
 
-            | Some v ->
-                CollectionBuilder<'msg, IFlexLayout, IView>(
-                    FlexLayout.WidgetKey,
-                    LayoutOfView.Children,
-                    FlexLayout.Wrap.WithValue(v)
-                )
+            | Some v -> CollectionBuilder<'msg, IFlexLayout, IView>(FlexLayout.WidgetKey, LayoutOfView.Children, FlexLayout.Wrap.WithValue(v))
 
 [<Extension>]
 type FlexLayoutModifiers =

--- a/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
@@ -10,22 +10,18 @@ type IFrame =
 module Frame =
     let WidgetKey = Widgets.register<Frame>()
 
-    let BorderColor =
-        Attributes.defineBindableAppThemeColor Frame.BorderColorProperty
+    let BorderColor = Attributes.defineBindableAppThemeColor Frame.BorderColorProperty
 
-    let CornerRadius =
-        Attributes.defineBindableFloat Frame.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableFloat Frame.CornerRadiusProperty
 
-    let HasShadow =
-        Attributes.defineBindableBool Frame.HasShadowProperty
+    let HasShadow = Attributes.defineBindableBool Frame.HasShadowProperty
 
 [<AutoOpen>]
 module FrameBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Frame<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-            WidgetHelpers.buildWidgets<'msg, IFrame>
-                Frame.WidgetKey
-                [| ContentView.Content.WithValue(content.Compile()) |]
+            WidgetHelpers.buildWidgets<'msg, IFrame> Frame.WidgetKey [| ContentView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]
 type FrameModifiers =

--- a/src/Fabulous.XamarinForms/Views/Layouts/Grid.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Grid.fs
@@ -8,7 +8,7 @@ type IGrid =
     inherit ILayoutOfView
 
 module GridUpdaters =
-    let updateGridColumnDefinitions _ (newValueOpt: Dimension [] voption) (node: IViewNode) =
+    let updateGridColumnDefinitions _ (newValueOpt: Dimension[] voption) (node: IViewNode) =
         let grid = node.Target :?> Grid
 
         match newValueOpt with
@@ -26,7 +26,7 @@ module GridUpdaters =
 
                 grid.ColumnDefinitions.Add(ColumnDefinition(Width = gridLength))
 
-    let updateGridRowDefinitions _ (newValueOpt: Dimension [] voption) (node: IViewNode) =
+    let updateGridRowDefinitions _ (newValueOpt: Dimension[] voption) (node: IViewNode) =
         let grid = node.Target :?> Grid
 
         match newValueOpt with
@@ -48,36 +48,27 @@ module Grid =
     let WidgetKey = Widgets.register<Grid>()
 
     let ColumnDefinitions =
-        Attributes.defineSimpleScalarWithEquality<Dimension array>
-            "Grid_ColumnDefinitions"
-            GridUpdaters.updateGridColumnDefinitions
+        Attributes.defineSimpleScalarWithEquality<Dimension array> "Grid_ColumnDefinitions" GridUpdaters.updateGridColumnDefinitions
 
     let RowDefinitions =
-        Attributes.defineSimpleScalarWithEquality<Dimension array>
-            "Grid_RowDefinitions"
-            GridUpdaters.updateGridRowDefinitions
+        Attributes.defineSimpleScalarWithEquality<Dimension array> "Grid_RowDefinitions" GridUpdaters.updateGridRowDefinitions
 
-    let Column =
-        Attributes.defineBindableInt Grid.ColumnProperty
+    let Column = Attributes.defineBindableInt Grid.ColumnProperty
 
-    let Row =
-        Attributes.defineBindableInt Grid.RowProperty
+    let Row = Attributes.defineBindableInt Grid.RowProperty
 
-    let ColumnSpacing =
-        Attributes.defineBindableFloat Grid.ColumnSpacingProperty
+    let ColumnSpacing = Attributes.defineBindableFloat Grid.ColumnSpacingProperty
 
-    let RowSpacing =
-        Attributes.defineBindableFloat Grid.RowSpacingProperty
+    let RowSpacing = Attributes.defineBindableFloat Grid.RowSpacingProperty
 
-    let ColumnSpan =
-        Attributes.defineBindableInt Grid.ColumnSpanProperty
+    let ColumnSpan = Attributes.defineBindableInt Grid.ColumnSpanProperty
 
-    let RowSpan =
-        Attributes.defineBindableInt Grid.RowSpanProperty
+    let RowSpan = Attributes.defineBindableInt Grid.RowSpanProperty
 
 [<AutoOpen>]
 module GridBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline Grid<'msg>(coldefs: seq<Dimension>, rowdefs: seq<Dimension>) =
             CollectionBuilder<'msg, IGrid, IView>(
                 Grid.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Layouts/RefreshView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/RefreshView.fs
@@ -11,8 +11,7 @@ type IRefreshView =
 module RefreshView =
     let WidgetKey = Widgets.register<RefreshView>()
 
-    let IsRefreshing =
-        Attributes.defineBindableBool RefreshView.IsRefreshingProperty
+    let IsRefreshing = Attributes.defineBindableBool RefreshView.IsRefreshingProperty
 
     let RefreshColor =
         Attributes.defineBindableAppThemeColor RefreshView.RefreshColorProperty
@@ -23,19 +22,12 @@ module RefreshView =
 [<AutoOpen>]
 module RefreshViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline RefreshView<'msg, 'marker when 'marker :> IView>
-            (
-                isRefreshing: bool,
-                onRefreshing: 'msg,
-                content: WidgetBuilder<'msg, 'marker>
-            ) =
+
+        static member inline RefreshView<'msg, 'marker when 'marker :> IView>(isRefreshing: bool, onRefreshing: 'msg, content: WidgetBuilder<'msg, 'marker>) =
             WidgetBuilder<'msg, IRefreshView>(
                 RefreshView.WidgetKey,
                 AttributesBundle(
-                    StackList.two(
-                        RefreshView.IsRefreshing.WithValue(isRefreshing),
-                        RefreshView.Refreshing.WithValue(onRefreshing)
-                    ),
+                    StackList.two(RefreshView.IsRefreshing.WithValue(isRefreshing), RefreshView.Refreshing.WithValue(onRefreshing)),
                     ValueSome [| ContentView.Content.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.XamarinForms/Views/Layouts/RelativeLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/RelativeLayout.fs
@@ -29,6 +29,7 @@ module RelativeLayout =
 [<AutoOpen>]
 module RelativeLayoutBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline RelativeLayout<'msg>() =
             CollectionBuilder<'msg, IRelativeLayout, IView>(RelativeLayout.WidgetKey, LayoutOfView.Children)
 

--- a/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
@@ -16,11 +16,9 @@ module ScrollView =
     let Orientation =
         Attributes.defineBindableEnum<ScrollOrientation> ScrollView.OrientationProperty
 
-    let ScrollX =
-        Attributes.defineBindableFloat ScrollView.ScrollXProperty
+    let ScrollX = Attributes.defineBindableFloat ScrollView.ScrollXProperty
 
-    let ScrollY =
-        Attributes.defineBindableFloat ScrollView.ScrollYProperty
+    let ScrollY = Attributes.defineBindableFloat ScrollView.ScrollYProperty
 
     let HorizontalScrollBarVisibility =
         Attributes.defineBindableEnum<ScrollBarVisibility> ScrollView.HorizontalScrollBarVisibilityProperty
@@ -38,24 +36,19 @@ module ScrollView =
         Attributes.defineEvent<ScrolledEventArgs> "ScrollView_Scrolled" (fun target -> (target :?> ScrollView).Scrolled)
 
     let ScrollTo =
-        Attributes.defineSimpleScalarWithEquality<ScrollToData>
-            "ScrollView_ScrollTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> ScrollView
+        Attributes.defineSimpleScalarWithEquality<ScrollToData> "ScrollView_ScrollTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> ScrollView
 
-                match newValueOpt with
-                | ValueNone -> view.ScrollToAsync(0., 0., true) |> ignore
-                | ValueSome data ->
-                    view.ScrollToAsync(data.X, data.Y, data.Animated)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.ScrollToAsync(0., 0., true) |> ignore
+            | ValueSome data -> view.ScrollToAsync(data.X, data.Y, data.Animated) |> ignore)
 
 [<AutoOpen>]
 module ScrollViewBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ScrollView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-            WidgetHelpers.buildWidgets<'msg, IScrollView>
-                ScrollView.WidgetKey
-                [| ScrollView.Content.WithValue(content.Compile()) |]
+            WidgetHelpers.buildWidgets<'msg, IScrollView> ScrollView.WidgetKey [| ScrollView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]
 type ScrollViewModifiers =
@@ -69,21 +62,13 @@ type ScrollViewModifiers =
     /// <summary>Sets when the horizontal scroll bar is visible.</summary>
     /// <param name="value">of type ScrollBarVisibility.</param>
     [<Extension>]
-    static member inline horizontalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IScrollView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline horizontalScrollBarVisibility(this: WidgetBuilder<'msg, #IScrollView>, value: ScrollBarVisibility) =
         this.AddScalar(ScrollView.HorizontalScrollBarVisibility.WithValue(value))
 
     /// <summary>Sets when the vertical scroll bar is visible.</summary>
     /// <param name="value">of type ScrollBarVisibility.</param>
     [<Extension>]
-    static member inline verticalScrollBarVisibility
-        (
-            this: WidgetBuilder<'msg, #IScrollView>,
-            value: ScrollBarVisibility
-        ) =
+    static member inline verticalScrollBarVisibility(this: WidgetBuilder<'msg, #IScrollView>, value: ScrollBarVisibility) =
         this.AddScalar(ScrollView.VerticalScrollBarVisibility.WithValue(value))
 
     /// <summary>Sets the current X scroll position.</summary>

--- a/src/Fabulous.XamarinForms/Views/Layouts/StackLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/StackLayout.fs
@@ -13,20 +13,15 @@ module StackLayout =
     let Orientation =
         Attributes.defineBindableEnum<StackOrientation> StackLayout.OrientationProperty
 
-    let Spacing =
-        Attributes.defineBindableFloat StackLayout.SpacingProperty
+    let Spacing = Attributes.defineBindableFloat StackLayout.SpacingProperty
 
 [<AutoOpen>]
 module StackLayoutBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline private StackLayout<'msg>(orientation: StackOrientation, ?spacing: float) =
             match spacing with
-            | None ->
-                CollectionBuilder<'msg, IStackLayout, IView>(
-                    StackLayout.WidgetKey,
-                    LayoutOfView.Children,
-                    StackLayout.Orientation.WithValue(orientation)
-                )
+            | None -> CollectionBuilder<'msg, IStackLayout, IView>(StackLayout.WidgetKey, LayoutOfView.Children, StackLayout.Orientation.WithValue(orientation))
 
             | Some v ->
                 CollectionBuilder<'msg, IStackLayout, IView>(

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItem.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItem.fs
@@ -14,8 +14,7 @@ module SwipeItem =
     let BackgroundColor =
         Attributes.defineBindableAppThemeColor SwipeItem.BackgroundColorProperty
 
-    let IsVisible =
-        Attributes.defineBindableBool SwipeItem.IsVisibleProperty
+    let IsVisible = Attributes.defineBindableBool SwipeItem.IsVisibleProperty
 
     let Clicked =
         Attributes.defineEvent "SwipeItem_Invoked" (fun target -> (target :?> SwipeItem).Invoked)
@@ -24,6 +23,7 @@ module SwipeItem =
 module SwipeItemBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline SwipeItem<'msg>(onInvoked: 'msg) =
             WidgetBuilder<'msg, ISwipeItem>(SwipeItem.WidgetKey, SwipeItem.Clicked.WithValue(fun _ -> onInvoked |> box))
 

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
@@ -13,9 +13,7 @@ module SwipeItems =
     let WidgetKey = Widgets.register<SwipeItems>()
 
     let SwipeItems =
-        Attributes.defineListWidgetCollection
-            "SwipeItems_SwipeItems"
-            (fun target -> (target :?> SwipeItems) :> IList<_>)
+        Attributes.defineListWidgetCollection "SwipeItems_SwipeItems" (fun target -> (target :?> SwipeItems) :> IList<_>)
 
     let SwipeMode =
         Attributes.defineBindableEnum<SwipeMode> Xamarin.Forms.SwipeItems.ModeProperty
@@ -27,11 +25,9 @@ module SwipeItems =
 module SwipeItemsBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline SwipeItems<'msg>() =
-            CollectionBuilder<'msg, ISwipeItems, Fabulous.XamarinForms.ISwipeItem>(
-                SwipeItems.WidgetKey,
-                SwipeItems.SwipeItems
-            )
+            CollectionBuilder<'msg, ISwipeItems, Fabulous.XamarinForms.ISwipeItem>(SwipeItems.WidgetKey, SwipeItems.SwipeItems)
 
 [<Extension>]
 type SwipeItemsModifiers() =
@@ -40,11 +36,7 @@ type SwipeItemsModifiers() =
         this.AddScalar(SwipeItems.SwipeMode.WithValue(value))
 
     [<Extension>]
-    static member inline swipeBehaviorOnInvoked
-        (
-            this: WidgetBuilder<'msg, #ISwipeItems>,
-            value: SwipeBehaviorOnInvoked
-        ) =
+    static member inline swipeBehaviorOnInvoked(this: WidgetBuilder<'msg, #ISwipeItems>, value: SwipeBehaviorOnInvoked) =
         this.AddScalar(SwipeItems.SwipeBehaviorOnInvoked.WithValue(value))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeView.fs
@@ -11,54 +11,38 @@ module SwipeView =
 
     let WidgetKey = Widgets.register<SwipeView>()
 
-    let LeftSwipeItems =
-        Attributes.defineBindableWidget SwipeView.LeftItemsProperty
+    let LeftSwipeItems = Attributes.defineBindableWidget SwipeView.LeftItemsProperty
 
-    let TopSwipeItems =
-        Attributes.defineBindableWidget SwipeView.TopItemsProperty
+    let TopSwipeItems = Attributes.defineBindableWidget SwipeView.TopItemsProperty
 
-    let RightSwipeItems =
-        Attributes.defineBindableWidget SwipeView.RightItemsProperty
+    let RightSwipeItems = Attributes.defineBindableWidget SwipeView.RightItemsProperty
 
-    let BottomSwipeItems =
-        Attributes.defineBindableWidget SwipeView.BottomItemsProperty
+    let BottomSwipeItems = Attributes.defineBindableWidget SwipeView.BottomItemsProperty
 
-    let SwipeThreshold =
-        Attributes.defineBindableInt SwipeView.ThresholdProperty
+    let SwipeThreshold = Attributes.defineBindableInt SwipeView.ThresholdProperty
 
     let SwipeStarted =
-        Attributes.defineEvent<SwipeStartedEventArgs>
-            "SwipeView_SwipeStarted"
-            (fun target -> (target :?> SwipeView).SwipeStarted)
+        Attributes.defineEvent<SwipeStartedEventArgs> "SwipeView_SwipeStarted" (fun target -> (target :?> SwipeView).SwipeStarted)
 
     let SwipeChanging =
-        Attributes.defineEvent<SwipeChangingEventArgs>
-            "SwipeView_SwipeChanging"
-            (fun target -> (target :?> SwipeView).SwipeChanging)
+        Attributes.defineEvent<SwipeChangingEventArgs> "SwipeView_SwipeChanging" (fun target -> (target :?> SwipeView).SwipeChanging)
 
     let SwipeEnded =
-        Attributes.defineEvent<SwipeEndedEventArgs>
-            "SwipeView_SwipeEnded"
-            (fun target -> (target :?> SwipeView).SwipeEnded)
+        Attributes.defineEvent<SwipeEndedEventArgs> "SwipeView_SwipeEnded" (fun target -> (target :?> SwipeView).SwipeEnded)
 
     let OpenRequested =
-        Attributes.defineEvent<OpenRequestedEventArgs>
-            "SwipeView_OpenRequested"
-            (fun target -> (target :?> SwipeView).OpenRequested)
+        Attributes.defineEvent<OpenRequestedEventArgs> "SwipeView_OpenRequested" (fun target -> (target :?> SwipeView).OpenRequested)
 
     let CloseRequested =
-        Attributes.defineEvent<CloseRequestedEventArgs>
-            "SwipeView_CloseRequested"
-            (fun target -> (target :?> SwipeView).CloseRequested)
+        Attributes.defineEvent<CloseRequestedEventArgs> "SwipeView_CloseRequested" (fun target -> (target :?> SwipeView).CloseRequested)
 
 [<AutoOpen>]
 module SwipeViewBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline SwipeView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-            WidgetHelpers.buildWidgets<'msg, ISwipeView>
-                SwipeView.WidgetKey
-                [| ContentView.Content.WithValue(content.Compile()) |]
+            WidgetHelpers.buildWidgets<'msg, ISwipeView> SwipeView.WidgetKey [| ContentView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]
 type SwipeViewModifiers() =
@@ -100,43 +84,23 @@ type SwipeViewModifiers() =
         this.AddScalar(SwipeView.SwipeThreshold.WithValue(threshold))
 
     [<Extension>]
-    static member inline onSwipeStarted
-        (
-            this: WidgetBuilder<'msg, #ISwipeView>,
-            onSwipeStarted: SwipeStartedEventArgs -> 'msg
-        ) =
+    static member inline onSwipeStarted(this: WidgetBuilder<'msg, #ISwipeView>, onSwipeStarted: SwipeStartedEventArgs -> 'msg) =
         this.AddScalar(SwipeView.SwipeStarted.WithValue(fun args -> onSwipeStarted args |> box))
 
     [<Extension>]
-    static member inline onSwipeChanging
-        (
-            this: WidgetBuilder<'msg, #ISwipeView>,
-            onSwipeChanging: SwipeChangingEventArgs -> 'msg
-        ) =
+    static member inline onSwipeChanging(this: WidgetBuilder<'msg, #ISwipeView>, onSwipeChanging: SwipeChangingEventArgs -> 'msg) =
         this.AddScalar(SwipeView.SwipeChanging.WithValue(fun args -> onSwipeChanging args |> box))
 
     [<Extension>]
-    static member inline onSwipeEnded
-        (
-            this: WidgetBuilder<'msg, #ISwipeView>,
-            onSwipeEnded: SwipeEndedEventArgs -> 'msg
-        ) =
+    static member inline onSwipeEnded(this: WidgetBuilder<'msg, #ISwipeView>, onSwipeEnded: SwipeEndedEventArgs -> 'msg) =
         this.AddScalar(SwipeView.SwipeEnded.WithValue(fun args -> onSwipeEnded args |> box))
 
     [<Extension>]
-    static member inline onOpenRequested
-        (
-            this: WidgetBuilder<'msg, #ISwipeView>,
-            onOpenRequested: OpenRequestedEventArgs -> 'msg
-        ) =
+    static member inline onOpenRequested(this: WidgetBuilder<'msg, #ISwipeView>, onOpenRequested: OpenRequestedEventArgs -> 'msg) =
         this.AddScalar(SwipeView.OpenRequested.WithValue(fun args -> onOpenRequested args |> box))
 
     [<Extension>]
-    static member inline onCloseRequested
-        (
-            this: WidgetBuilder<'msg, #ISwipeView>,
-            onCloseRequested: CloseRequestedEventArgs -> 'msg
-        ) =
+    static member inline onCloseRequested(this: WidgetBuilder<'msg, #ISwipeView>, onCloseRequested: CloseRequestedEventArgs -> 'msg) =
         this.AddScalar(SwipeView.CloseRequested.WithValue(fun args -> onCloseRequested args |> box))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Layouts/_Layout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/_Layout.fs
@@ -31,14 +31,7 @@ type LayoutModifiers =
         LayoutModifiers.padding(this, Thickness(value))
 
     [<Extension>]
-    static member inline padding
-        (
-            this: WidgetBuilder<'msg, #ILayout>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline padding(this: WidgetBuilder<'msg, #ILayout>, left: float, top: float, right: float, bottom: float) =
         LayoutModifiers.padding(this, Thickness(left, top, right, bottom))
 
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Layouts/_LayoutOfView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/_LayoutOfView.fs
@@ -8,6 +8,4 @@ type ILayoutOfView =
 
 module LayoutOfView =
     let Children =
-        Attributes.defineListWidgetCollection
-            "LayoutOfWidget_Children"
-            (fun target -> (target :?> Xamarin.Forms.Layout<View>).Children)
+        Attributes.defineListWidgetCollection "LayoutOfWidget_Children" (fun target -> (target :?> Xamarin.Forms.Layout<View>).Children)

--- a/src/Fabulous.XamarinForms/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.XamarinForms/Views/MenuItems/MenuItem.fs
@@ -18,14 +18,11 @@ module MenuItem =
     let IconImageSource =
         Attributes.defineBindableAppTheme<ImageSource> MenuItem.IconImageSourceProperty
 
-    let IsDestructive =
-        Attributes.defineBindableBool MenuItem.IsDestructiveProperty
+    let IsDestructive = Attributes.defineBindableBool MenuItem.IsDestructiveProperty
 
-    let IsEnabled =
-        Attributes.defineBindableBool MenuItem.IsEnabledProperty
+    let IsEnabled = Attributes.defineBindableBool MenuItem.IsEnabledProperty
 
-    let Text =
-        Attributes.defineBindableWithEquality<string> MenuItem.TextProperty
+    let Text = Attributes.defineBindableWithEquality<string> MenuItem.TextProperty
 
     let Clicked =
         Attributes.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> MenuItem).Clicked)
@@ -33,12 +30,9 @@ module MenuItem =
 [<AutoOpen>]
 module MenuItemBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline MenuItem<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IMenuItem>(
-                MenuItem.WidgetKey,
-                MenuItem.Text.WithValue(text),
-                MenuItem.Clicked.WithValue(onClicked)
-            )
+            WidgetBuilder<'msg, IMenuItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(onClicked))
 
 [<Extension>]
 type MenuItemModifiers =

--- a/src/Fabulous.XamarinForms/Views/MenuItems/ToolbarItem.fs
+++ b/src/Fabulous.XamarinForms/Views/MenuItems/ToolbarItem.fs
@@ -11,34 +11,27 @@ module ToolbarItem =
     let WidgetKey = Widgets.register<ToolbarItem>()
 
     let Order =
-        Attributes.defineEnum<ToolbarItemOrder>
-            "ToolbarItem_Order"
-            (fun _ newValueOpt node ->
-                let toolbarItem = node.Target :?> ToolbarItem
+        Attributes.defineEnum<ToolbarItemOrder> "ToolbarItem_Order" (fun _ newValueOpt node ->
+            let toolbarItem = node.Target :?> ToolbarItem
 
-                match newValueOpt with
-                | ValueNone -> toolbarItem.Order <- ToolbarItemOrder.Default
-                | ValueSome order -> toolbarItem.Order <- order)
+            match newValueOpt with
+            | ValueNone -> toolbarItem.Order <- ToolbarItemOrder.Default
+            | ValueSome order -> toolbarItem.Order <- order)
 
     let Priority =
-        Attributes.defineInt
-            "ToolbarItem_Priority"
-            (fun _ newValueOpt node ->
-                let toolbarItem = node.Target :?> ToolbarItem
+        Attributes.defineInt "ToolbarItem_Priority" (fun _ newValueOpt node ->
+            let toolbarItem = node.Target :?> ToolbarItem
 
-                match newValueOpt with
-                | ValueNone -> toolbarItem.Priority <- 0
-                | ValueSome priority -> toolbarItem.Priority <- priority)
+            match newValueOpt with
+            | ValueNone -> toolbarItem.Priority <- 0
+            | ValueSome priority -> toolbarItem.Priority <- priority)
 
 [<AutoOpen>]
 module ToolbarItemBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline ToolbarItem<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IToolbarItem>(
-                ToolbarItem.WidgetKey,
-                MenuItem.Text.WithValue(text),
-                MenuItem.Clicked.WithValue(onClicked)
-            )
+            WidgetBuilder<'msg, IToolbarItem>(ToolbarItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(onClicked))
 
 [<Extension>]
 type ToolbarItemModifiers =

--- a/src/Fabulous.XamarinForms/Views/Pages/ContentPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/ContentPage.fs
@@ -11,29 +11,19 @@ type IContentPage =
 module ContentPage =
     let WidgetKey = Widgets.register<FabulousContentPage>()
 
-    let Content =
-        Attributes.defineBindableWidget ContentPage.ContentProperty
+    let Content = Attributes.defineBindableWidget ContentPage.ContentProperty
 
     let SizeAllocated =
-        Attributes.defineEvent<SizeAllocatedEventArgs>
-            "ContentPage_SizeAllocated"
-            (fun target -> (target :?> FabulousContentPage).SizeAllocated)
+        Attributes.defineEvent<SizeAllocatedEventArgs> "ContentPage_SizeAllocated" (fun target -> (target :?> FabulousContentPage).SizeAllocated)
 
 [<AutoOpen>]
 module ContentPageBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline ContentPage<'msg, 'marker when 'marker :> IView>
-            (
-                title: string,
-                content: WidgetBuilder<'msg, 'marker>
-            ) =
+
+        static member inline ContentPage<'msg, 'marker when 'marker :> IView>(title: string, content: WidgetBuilder<'msg, 'marker>) =
             WidgetBuilder<'msg, IContentPage>(
                 ContentPage.WidgetKey,
-                AttributesBundle(
-                    StackList.one(Page.Title.WithValue(title)),
-                    ValueSome [| ContentPage.Content.WithValue(content.Compile()) |],
-                    ValueNone
-                )
+                AttributesBundle(StackList.one(Page.Title.WithValue(title)), ValueSome [| ContentPage.Content.WithValue(content.Compile()) |], ValueNone)
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
@@ -11,28 +11,22 @@ module FlyoutPage =
     let WidgetKey = Widgets.register<CustomFlyoutPage>()
 
     let CanChangeIsPresented =
-        Attributes.defineBool
-            "FlyoutPage_CanChangeIsPresented"
-            (fun _ newValueOpt node ->
-                let flyoutPage = node.Target :?> FlyoutPage
+        Attributes.defineBool "FlyoutPage_CanChangeIsPresented" (fun _ newValueOpt node ->
+            let flyoutPage = node.Target :?> FlyoutPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> flyoutPage.CanChangeIsPresented
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> flyoutPage.CanChangeIsPresented
+                | ValueSome v -> v
 
-                flyoutPage.CanChangeIsPresented <- value)
+            flyoutPage.CanChangeIsPresented <- value)
 
     let IsGestureEnabled =
         Attributes.defineBindableBool FlyoutPage.IsGestureEnabledProperty
 
     let IsPresented =
-        Attributes.defineBindableWithEvent<bool, bool>
-            "FlyoutPage_IsPresentedChanged"
-            FlyoutPage.IsPresentedProperty
-            (fun target ->
-                (target :?> CustomFlyoutPage)
-                    .CustomIsPresentedChanged)
+        Attributes.defineBindableWithEvent<bool, bool> "FlyoutPage_IsPresentedChanged" FlyoutPage.IsPresentedProperty (fun target ->
+            (target :?> CustomFlyoutPage).CustomIsPresentedChanged)
 
     let Flyout =
         Attributes.definePropertyWidget
@@ -41,17 +35,15 @@ module FlyoutPage =
             (fun target value -> (target :?> FlyoutPage).Flyout <- value)
 
     let FlyoutBounds =
-        Attributes.defineSimpleScalarWithEquality<Rectangle>
-            "FlyoutPage_FlyoutBounds"
-            (fun _ newValueOpt node ->
-                let flyoutPage = node.Target :?> FlyoutPage
+        Attributes.defineSimpleScalarWithEquality<Rectangle> "FlyoutPage_FlyoutBounds" (fun _ newValueOpt node ->
+            let flyoutPage = node.Target :?> FlyoutPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> flyoutPage.FlyoutBounds
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> flyoutPage.FlyoutBounds
+                | ValueSome v -> v
 
-                flyoutPage.FlyoutBounds <- value)
+            flyoutPage.FlyoutBounds <- value)
 
     let FlyoutLayoutBehavior =
         Attributes.defineBindableEnum<FlyoutLayoutBehavior> FlyoutPage.FlyoutLayoutBehaviorProperty
@@ -63,26 +55,23 @@ module FlyoutPage =
             (fun target value -> (target :?> FlyoutPage).Detail <- value)
 
     let DetailBounds =
-        Attributes.defineSimpleScalarWithEquality<Rectangle>
-            "FlyoutPage_DetailBounds"
-            (fun _ newValueOpt node ->
-                let flyoutPage = node.Target :?> FlyoutPage
+        Attributes.defineSimpleScalarWithEquality<Rectangle> "FlyoutPage_DetailBounds" (fun _ newValueOpt node ->
+            let flyoutPage = node.Target :?> FlyoutPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> flyoutPage.DetailBounds
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> flyoutPage.DetailBounds
+                | ValueSome v -> v
 
-                flyoutPage.DetailBounds <- value)
+            flyoutPage.DetailBounds <- value)
 
     let BackButtonPressed =
-        Attributes.defineEvent<BackButtonPressedEventArgs>
-            "FlyoutPage_BackButtonPressed"
-            (fun target -> (target :?> FlyoutPage).BackButtonPressed)
+        Attributes.defineEvent<BackButtonPressedEventArgs> "FlyoutPage_BackButtonPressed" (fun target -> (target :?> FlyoutPage).BackButtonPressed)
 
 [<AutoOpen>]
 module FlyoutPageBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline FlyoutPage<'msg, 'flyout, 'detail when 'flyout :> IPage and 'detail :> IPage>
             (
                 flyout: WidgetBuilder<'msg, 'flyout>,
@@ -121,11 +110,7 @@ type FlyoutPageModifiers =
         this.AddScalar(FlyoutPage.DetailBounds.WithValue(value))
 
     [<Extension>]
-    static member inline onBackButtonPressed
-        (
-            this: WidgetBuilder<'msg, #IFlyoutPage>,
-            onBackButtonPressed: bool -> 'msg
-        ) =
+    static member inline onBackButtonPressed(this: WidgetBuilder<'msg, #IFlyoutPage>, onBackButtonPressed: bool -> 'msg) =
         this.AddScalar(FlyoutPage.BackButtonPressed.WithValue(fun args -> onBackButtonPressed args.Handled |> box))
 
     /// <summary>Link a ViewRef to access the direct ContentPage control instance</summary>

--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -20,8 +20,7 @@ type INavigationPage =
 type CustomNavigationPage() as this =
     inherit NavigationPage()
 
-    let _pagesSync =
-        System.Collections.Generic.List(this.Pages)
+    let _pagesSync = System.Collections.Generic.List(this.Pages)
 
     let mutable popCount = 0
 
@@ -36,14 +35,12 @@ type CustomNavigationPage() as this =
     [<CLIEvent>]
     member _.BackButtonPressed = backButtonPressed.Publish
 
-    member this.PagesSync =
-        _pagesSync :> System.Collections.Generic.IReadOnlyList<Page>
+    member this.PagesSync = _pagesSync :> System.Collections.Generic.IReadOnlyList<Page>
 
     member this.PushSync(page: Page, ?animated: bool) =
         _pagesSync.Add(page)
 
-        this.PushAsync(page, (animated <> Some false))
-        |> ignore
+        this.PushAsync(page, (animated <> Some false)) |> ignore
 
     member this.InsertPageBeforeSync(page: Page, index: int) =
         let next = _pagesSync.[index]
@@ -90,7 +87,7 @@ module NavigationPageUpdaters =
 
         for diff in diffs do
             match diff with
-            | WidgetCollectionItemChange.Insert (index, widget) ->
+            | WidgetCollectionItemChange.Insert(index, widget) ->
                 let struct (_, page) = Helpers.createViewForWidget node widget
                 let page = page :?> Page
 
@@ -99,15 +96,13 @@ module NavigationPageUpdaters =
                 else
                     navigationPage.InsertPageBeforeSync(page, index)
 
-            | WidgetCollectionItemChange.Update (index, diff) ->
-                let childNode =
-                    node.TreeContext.GetViewNode(box pages.[index])
+            | WidgetCollectionItemChange.Update(index, diff) ->
+                let childNode = node.TreeContext.GetViewNode(box pages.[index])
 
                 childNode.ApplyDiff(&diff)
 
-            | WidgetCollectionItemChange.Replace (index, _, newWidget) ->
-                let struct (_, page) =
-                    Helpers.createViewForWidget node newWidget
+            | WidgetCollectionItemChange.Replace(index, _, newWidget) ->
+                let struct (_, page) = Helpers.createViewForWidget node newWidget
 
                 let page = page :?> Page
 
@@ -127,7 +122,7 @@ module NavigationPageUpdaters =
                     navigationPage.RemovePageSync(index)
                     navigationPage.InsertPageBeforeSync(page, index + 1)
 
-            | WidgetCollectionItemChange.Remove (index, _) ->
+            | WidgetCollectionItemChange.Remove(index, _) ->
                 if index = pages.Length - 1 then
                     popLastWithAnimation <- true
                 else
@@ -136,11 +131,7 @@ module NavigationPageUpdaters =
         if popLastWithAnimation then
             navigationPage.PopSync()
 
-    let updateNavigationPagePages
-        (oldValueOpt: ArraySlice<Widget> voption)
-        (newValueOpt: ArraySlice<Widget> voption)
-        (node: IViewNode)
-        =
+    let updateNavigationPagePages (oldValueOpt: ArraySlice<Widget> voption) (newValueOpt: ArraySlice<Widget> voption) (node: IViewNode) =
         let navigationPage = node.Target :?> CustomNavigationPage
 
         match newValueOpt with
@@ -202,80 +193,62 @@ module NavigationPage =
         Attributes.defineBindableAppTheme<ImageSource> NavigationPage.TitleIconImageSourceProperty
 
     let BackNavigated =
-        Attributes.defineEventNoArg
-            "NavigationPage_BackNavigated"
-            (fun target -> (target :?> CustomNavigationPage).BackNavigated)
+        Attributes.defineEventNoArg "NavigationPage_BackNavigated" (fun target -> (target :?> CustomNavigationPage).BackNavigated)
 
     let BackButtonPressed =
-        Attributes.defineEventNoArg
-            "NavigationPage_BackButtonPressed"
-            (fun target ->
-                (target :?> CustomNavigationPage)
-                    .BackButtonPressed)
+        Attributes.defineEventNoArg "NavigationPage_BackButtonPressed" (fun target -> (target :?> CustomNavigationPage).BackButtonPressed)
 
     [<Obsolete("Use BackNavigated instead")>]
     let Popped =
-        Attributes.defineEvent<NavigationEventArgs>
-            "NavigationPage_Popped"
-            (fun target -> (target :?> NavigationPage).Popped)
+        Attributes.defineEvent<NavigationEventArgs> "NavigationPage_Popped" (fun target -> (target :?> NavigationPage).Popped)
 
     [<Obsolete("Will be removed in next major version")>]
     let Pushed =
-        Attributes.defineEvent<NavigationEventArgs>
-            "NavigationPage_Pushed"
-            (fun target -> (target :?> NavigationPage).Pushed)
+        Attributes.defineEvent<NavigationEventArgs> "NavigationPage_Pushed" (fun target -> (target :?> NavigationPage).Pushed)
 
     [<Obsolete("Use BackNavigated instead")>]
     let PoppedToRoot =
-        Attributes.defineEvent<NavigationEventArgs>
-            "NavigationPage_PoppedToRoot"
-            (fun target -> (target :?> NavigationPage).PoppedToRoot)
+        Attributes.defineEvent<NavigationEventArgs> "NavigationPage_PoppedToRoot" (fun target -> (target :?> NavigationPage).PoppedToRoot)
 
-    let TitleView =
-        Attributes.defineBindableWidget NavigationPage.TitleViewProperty
+    let TitleView = Attributes.defineBindableWidget NavigationPage.TitleViewProperty
 
     let HideNavigationBarSeparator =
-        Attributes.defineBool
-            "NavigationPage_HideNavigationBarSeparator"
-            (fun _ newValueOpt node ->
-                let page = node.Target :?> NavigationPage
+        Attributes.defineBool "NavigationPage_HideNavigationBarSeparator" (fun _ newValueOpt node ->
+            let page = node.Target :?> NavigationPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                iOSSpecific.NavigationPage.SetHideNavigationBarSeparator(page, value))
+            iOSSpecific.NavigationPage.SetHideNavigationBarSeparator(page, value))
 
     let IsNavigationBarTranslucent =
-        Attributes.defineBool
-            "NavigationPage_IsNavigationBarTranslucent"
-            (fun _ newValueOpt node ->
-                let page = node.Target :?> NavigationPage
+        Attributes.defineBool "NavigationPage_IsNavigationBarTranslucent" (fun _ newValueOpt node ->
+            let page = node.Target :?> NavigationPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                iOSSpecific.NavigationPage.SetIsNavigationBarTranslucent(page, value))
+            iOSSpecific.NavigationPage.SetIsNavigationBarTranslucent(page, value))
 
     let PrefersLargeTitles =
-        Attributes.defineBool
-            "NavigationPage_PrefersLargeTitles"
-            (fun _ newValueOpt node ->
-                let page = node.Target :?> NavigationPage
+        Attributes.defineBool "NavigationPage_PrefersLargeTitles" (fun _ newValueOpt node ->
+            let page = node.Target :?> NavigationPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                iOSSpecific.NavigationPage.SetPrefersLargeTitles(page, value))
+            iOSSpecific.NavigationPage.SetPrefersLargeTitles(page, value))
 
 [<AutoOpen>]
 module NavigationPageBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline NavigationPage<'msg>() =
             CollectionBuilder<'msg, INavigationPage, IPage>(NavigationPage.WidgetKey, NavigationPage.Pages)
 
@@ -285,12 +258,7 @@ type NavigationPageModifiers =
     /// <param name="light">The color of the barBackgroundColor in the light theme.</param>
     /// <param name="dark">The color of the barBackgroundColor in the dark theme.</param>
     [<Extension>]
-    static member inline barBackgroundColor
-        (
-            this: WidgetBuilder<'msg, #INavigationPage>,
-            light: FabColor,
-            ?dark: FabColor
-        ) =
+    static member inline barBackgroundColor(this: WidgetBuilder<'msg, #INavigationPage>, light: FabColor, ?dark: FabColor) =
         this.AddScalar(NavigationPage.BarBackgroundColor.WithValue(AppTheme.create light dark))
 
     /// <summary>Set the color of the BarBackground.</summary>

--- a/src/Fabulous.XamarinForms/Views/Pages/TabbedPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/TabbedPage.fs
@@ -24,27 +24,22 @@ module TabbedPage =
         Attributes.defineBindableAppThemeColor TabbedPage.UnselectedTabColorProperty
 
     let ToolbarPlacement =
-        Attributes.defineSimpleScalarWithEquality<AndroidSpecific.ToolbarPlacement>
-            "TabbedPage_ToolbarPlacement"
-            (fun _ newValueOpt node ->
-                let tabbedPage = node.Target :?> TabbedPage
+        Attributes.defineSimpleScalarWithEquality<AndroidSpecific.ToolbarPlacement> "TabbedPage_ToolbarPlacement" (fun _ newValueOpt node ->
+            let tabbedPage = node.Target :?> TabbedPage
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> AndroidSpecific.ToolbarPlacement.Default
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> AndroidSpecific.ToolbarPlacement.Default
+                | ValueSome v -> v
 
-                AndroidSpecific.TabbedPage.SetToolbarPlacement(tabbedPage, value))
+            AndroidSpecific.TabbedPage.SetToolbarPlacement(tabbedPage, value))
 
 [<AutoOpen>]
 module TabbedPageBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline TabbedPage<'msg>(title: string) =
-            CollectionBuilder<'msg, ITabbedPage, IPage>(
-                TabbedPage.WidgetKey,
-                MultiPageOfPage.Children,
-                Page.Title.WithValue(title)
-            )
+            CollectionBuilder<'msg, ITabbedPage, IPage>(TabbedPage.WidgetKey, MultiPageOfPage.Children, Page.Title.WithValue(title))
 
 [<Extension>]
 type TabbedPageModifiers =

--- a/src/Fabulous.XamarinForms/Views/Pages/_MultiPageOfPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/_MultiPageOfPage.fs
@@ -12,18 +12,12 @@ module MultiPageOfPage =
         Attributes.defineListWidgetCollection "MultiPageOfPage" (fun target -> (target :?> MultiPage<Page>).Children)
 
     let CurrentPageChanged =
-        Attributes.defineEventNoArg
-            "MultiPageOfPage_CurrentPageChanged"
-            (fun target -> (target :?> MultiPage<Page>).CurrentPageChanged)
+        Attributes.defineEventNoArg "MultiPageOfPage_CurrentPageChanged" (fun target -> (target :?> MultiPage<Page>).CurrentPageChanged)
 
 [<Extension>]
 type MultiPageOfPageModifiers =
     /// <summary>Raised when the CurrentPage property changes.</summary>
     /// <param name="onCurrentPageChanged">The msg to invoke when the CurrentPage property changes.</param>
     [<Extension>]
-    static member inline onCurrentPageChanged
-        (
-            this: WidgetBuilder<'msg, #IMultiPageOfPage>,
-            onCurrentPageChanged: 'msg
-        ) =
+    static member inline onCurrentPageChanged(this: WidgetBuilder<'msg, #IMultiPageOfPage>, onCurrentPageChanged: 'msg) =
         this.AddScalar(MultiPageOfPage.CurrentPageChanged.WithValue(onCurrentPageChanged))

--- a/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
@@ -17,19 +17,14 @@ module Page =
     let IconImageSource =
         Attributes.defineBindableAppTheme<ImageSource> Page.IconImageSourceProperty
 
-    let IsBusy =
-        Attributes.defineBindableBool Page.IsBusyProperty
+    let IsBusy = Attributes.defineBindableBool Page.IsBusyProperty
 
-    let Padding =
-        Attributes.defineBindableWithEquality<Thickness> Page.PaddingProperty
+    let Padding = Attributes.defineBindableWithEquality<Thickness> Page.PaddingProperty
 
-    let Title =
-        Attributes.defineBindableWithEquality<string> Page.TitleProperty
+    let Title = Attributes.defineBindableWithEquality<string> Page.TitleProperty
 
     let ToolbarItems =
-        Attributes.defineListWidgetCollection<ToolbarItem>
-            "Page_ToolbarItems"
-            (fun target -> (target :?> Page).ToolbarItems)
+        Attributes.defineListWidgetCollection<ToolbarItem> "Page_ToolbarItems" (fun target -> (target :?> Page).ToolbarItems)
 
     let Appearing =
         Attributes.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Page).Appearing)
@@ -41,17 +36,15 @@ module Page =
         Attributes.defineEventNoArg "Page_LayoutChanged" (fun target -> (target :?> Page).LayoutChanged)
 
     let UseSafeArea =
-        Attributes.defineSimpleScalarWithEquality<bool>
-            "Page_UseSafeArea"
-            (fun _ newValueOpt node ->
-                let page = node.Target :?> Page
+        Attributes.defineSimpleScalarWithEquality<bool> "Page_UseSafeArea" (fun _ newValueOpt node ->
+            let page = node.Target :?> Page
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> false
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> false
+                | ValueSome v -> v
 
-                iOSSpecific.Page.SetUseSafeArea(page, value))
+            iOSSpecific.Page.SetUseSafeArea(page, value))
 
 [<Extension>]
 type PageModifiers =
@@ -195,14 +188,7 @@ type PageModifiers =
         PageModifiers.padding(this, Thickness(value))
 
     [<Extension>]
-    static member inline padding
-        (
-            this: WidgetBuilder<'msg, #IPage>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline padding(this: WidgetBuilder<'msg, #IPage>, left: float, top: float, right: float, bottom: float) =
         PageModifiers.padding(this, Thickness(left, top, right, bottom))
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Shapes/Ellipse.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Ellipse.fs
@@ -17,6 +17,7 @@ module Ellipse =
 module EllipseBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline Ellipse<'msg>(strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IEllipse>(
                 Ellipse.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/EllipseGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/EllipseGeometry.fs
@@ -13,16 +13,15 @@ module EllipseGeometry =
     let Center =
         Attributes.defineBindableWithEquality<Point> EllipseGeometry.CenterProperty
 
-    let RadiusX =
-        Attributes.defineBindableFloat EllipseGeometry.RadiusXProperty
+    let RadiusX = Attributes.defineBindableFloat EllipseGeometry.RadiusXProperty
 
-    let RadiusY =
-        Attributes.defineBindableFloat EllipseGeometry.RadiusYProperty
+    let RadiusY = Attributes.defineBindableFloat EllipseGeometry.RadiusYProperty
 
 [<AutoOpen>]
 module EllipseGeometryBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline EllipseGeometry<'msg>(center: Point, radiusX: float, radiusY: float) =
             WidgetBuilder<'msg, IEllipseGeometry>(
                 EllipseGeometry.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
@@ -12,9 +12,7 @@ module GeometryGroup =
     let WidgetKey = Widgets.register<GeometryGroup>()
 
     let Children =
-        Attributes.defineListWidgetCollection
-            "GeometryGroup_Children"
-            (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
+        Attributes.defineListWidgetCollection "GeometryGroup_Children" (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
 
     let FillRule =
         Attributes.defineBindableEnum<FillRule> GeometryGroup.FillRuleProperty
@@ -22,13 +20,9 @@ module GeometryGroup =
 [<AutoOpen>]
 module GeometryGroupBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline GeometryGroup<'msg>(?fillRule: FillRule) =
             match fillRule with
-            | None ->
-                CollectionBuilder<'msg, IGeometryGroup, IGeometry>(GeometryGroup.WidgetKey, GeometryGroup.Children)
+            | None -> CollectionBuilder<'msg, IGeometryGroup, IGeometry>(GeometryGroup.WidgetKey, GeometryGroup.Children)
             | Some fillRule ->
-                CollectionBuilder<'msg, IGeometryGroup, IGeometry>(
-                    GeometryGroup.WidgetKey,
-                    GeometryGroup.Children,
-                    GeometryGroup.FillRule.WithValue(fillRule)
-                )
+                CollectionBuilder<'msg, IGeometryGroup, IGeometry>(GeometryGroup.WidgetKey, GeometryGroup.Children, GeometryGroup.FillRule.WithValue(fillRule))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/LineGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/LineGeometry.fs
@@ -19,9 +19,6 @@ module LineGeometry =
 [<AutoOpen>]
 module LineGeometryBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline LineGeometry<'msg>(start: Point, end': Point) =
-            WidgetBuilder<'msg, ILineGeometry>(
-                LineGeometry.WidgetKey,
-                LineGeometry.StartPoint.WithValue(start),
-                LineGeometry.EndPoint.WithValue(end')
-            )
+            WidgetBuilder<'msg, ILineGeometry>(LineGeometry.WidgetKey, LineGeometry.StartPoint.WithValue(start), LineGeometry.EndPoint.WithValue(end'))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
@@ -12,36 +12,26 @@ module PathGeometry =
     let WidgetKey = Widgets.register<PathGeometry>()
 
     let FiguresWidgets =
-        Attributes.defineListWidgetCollection
-            "PathGeometry_FiguresWidgets"
-            (fun target -> (target :?> PathGeometry).Figures :> IList<_>)
+        Attributes.defineListWidgetCollection "PathGeometry_FiguresWidgets" (fun target -> (target :?> PathGeometry).Figures :> IList<_>)
 
     let FiguresString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "PathGeometry_FiguresString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "PathGeometry_FiguresString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PathGeometry.FiguresProperty)
-                | ValueSome value ->
-                    target.SetValue(
-                        PathGeometry.FiguresProperty,
-                        PathFigureCollectionConverter()
-                            .ConvertFromInvariantString(value)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PathGeometry.FiguresProperty)
+            | ValueSome value -> target.SetValue(PathGeometry.FiguresProperty, PathFigureCollectionConverter().ConvertFromInvariantString(value)))
 
-    let FillRule =
-        Attributes.defineBindableEnum<FillRule> PathGeometry.FillRuleProperty
+    let FillRule = Attributes.defineBindableEnum<FillRule> PathGeometry.FillRuleProperty
 
 [<AutoOpen>]
 module PathGeometryBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline PathGeometry<'msg>(?fillRule: FillRule) =
             match fillRule with
-            | None ->
-                CollectionBuilder<'msg, IPathGeometry, IPathFigure>(PathGeometry.WidgetKey, PathGeometry.FiguresWidgets)
+            | None -> CollectionBuilder<'msg, IPathGeometry, IPathFigure>(PathGeometry.WidgetKey, PathGeometry.FiguresWidgets)
             | Some fillRule ->
                 CollectionBuilder<'msg, IPathGeometry, IPathFigure>(
                     PathGeometry.WidgetKey,
@@ -51,11 +41,7 @@ module PathGeometryBuilders =
 
         static member inline PathGeometry<'msg>(content: string, ?fillRule: FillRule) =
             match fillRule with
-            | None ->
-                WidgetBuilder<'msg, IPathGeometry>(
-                    PathGeometry.WidgetKey,
-                    PathGeometry.FiguresString.WithValue(content)
-                )
+            | None -> WidgetBuilder<'msg, IPathGeometry>(PathGeometry.WidgetKey, PathGeometry.FiguresString.WithValue(content))
             | Some fillRule ->
                 WidgetBuilder<'msg, IPathGeometry>(
                     PathGeometry.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RectangleGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RectangleGeometry.fs
@@ -16,5 +16,6 @@ module RectangleGeometry =
 [<AutoOpen>]
 module RectangleGeometryBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline RectangleGeometry<'msg>(rect: Rect) =
             WidgetBuilder<'msg, IRectangleGeometry>(RectangleGeometry.WidgetKey, RectangleGeometry.Rect.WithValue(rect))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RoundRectangleGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RoundRectangleGeometry.fs
@@ -11,8 +11,7 @@ type IRoundRectangleGeometry =
 
 module RoundRectangleGeometry =
 
-    let WidgetKey =
-        Widgets.register<RoundRectangleGeometry>()
+    let WidgetKey = Widgets.register<RoundRectangleGeometry>()
 
     let CornerRadius =
         Attributes.defineBindableWithEquality<CornerRadius> RoundRectangleGeometry.CornerRadiusProperty
@@ -26,6 +25,7 @@ module RoundRectangleGeometry =
 [<AutoOpen>]
 module RoundRectangleGeometryBuilders =
     type Fabulous.XamarinForms.View with
+
         [<Obsolete("Use RoundRectangleGeometry(cornerRadius: CornerRadius, rect: Rect) instead")>]
         static member inline RoundRectangleGeometry<'msg>(cornerRadius: float, rect: Rect) =
             WidgetBuilder<'msg, IRoundRectangleGeometry>(

--- a/src/Fabulous.XamarinForms/Views/Shapes/Line.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Line.fs
@@ -13,35 +13,27 @@ module Line =
     let WidgetKey = Widgets.register<Line>()
 
     let Points =
-        Attributes.defineSimpleScalarWithEquality<struct (Point * Point)>
-            "Line_Point1"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> Line
+        Attributes.defineSimpleScalarWithEquality<struct (Point * Point)> "Line_Point1" (fun _ newValueOpt node ->
+            let line = node.Target :?> Line
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.X1 <- 0.
-                    line.Y1 <- 0.
-                    line.X2 <- 0.
-                    line.Y2 <- 0.
-                | ValueSome (startPoint, endPoint) ->
-                    line.X1 <- startPoint.X
-                    line.Y1 <- startPoint.Y
-                    line.X2 <- endPoint.X
-                    line.Y2 <- endPoint.Y)
+            match newValueOpt with
+            | ValueNone ->
+                line.X1 <- 0.
+                line.Y1 <- 0.
+                line.X2 <- 0.
+                line.Y2 <- 0.
+            | ValueSome(startPoint, endPoint) ->
+                line.X1 <- startPoint.X
+                line.Y1 <- startPoint.Y
+                line.X2 <- endPoint.X
+                line.Y2 <- endPoint.Y)
 
 [<AutoOpen>]
 module LineBuilders =
 
     type Fabulous.XamarinForms.View with
-        static member inline Line<'msg>
-            (
-                startPoint: Point,
-                endPoint: Point,
-                strokeThickness: float,
-                strokeLight: Brush,
-                ?strokeDark: Brush
-            ) =
+
+        static member inline Line<'msg>(startPoint: Point, endPoint: Point, strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, ILine>(
                 Line.WidgetKey,
                 Line.Points.WithValue(struct (startPoint, endPoint)),

--- a/src/Fabulous.XamarinForms/Views/Shapes/Path.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Path.fs
@@ -13,46 +13,32 @@ type IPath =
 module Path =
     let WidgetKey = Widgets.register<Path>()
 
-    let DataWidget =
-        Attributes.defineBindableWidget Path.DataProperty
+    let DataWidget = Attributes.defineBindableWidget Path.DataProperty
 
     let DataString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "Path_DataString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "Path_DataString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Path.DataProperty)
-                | ValueSome value ->
-                    target.SetValue(
-                        Path.DataProperty,
-                        PathGeometryConverter()
-                            .ConvertFromInvariantString(value)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Path.DataProperty)
+            | ValueSome value -> target.SetValue(Path.DataProperty, PathGeometryConverter().ConvertFromInvariantString(value)))
 
     let RenderTransformWidget =
         Attributes.defineBindableWidget Path.RenderTransformProperty
 
     let RenderTransformString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "Path_RenderTransformString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "Path_RenderTransformString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Path.RenderTransformProperty)
-                | ValueSome value ->
-                    target.SetValue(
-                        Path.RenderTransformProperty,
-                        TransformTypeConverter()
-                            .ConvertFromInvariantString(value)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Path.RenderTransformProperty)
+            | ValueSome value -> target.SetValue(Path.RenderTransformProperty, TransformTypeConverter().ConvertFromInvariantString(value)))
 
 [<AutoOpen>]
 module PathBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline Path<'msg, 'marker when 'marker :> IGeometry>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IPath> Path.WidgetKey [| Path.DataWidget.WithValue(content.Compile()) |]
 

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
@@ -11,77 +11,61 @@ module CompositeTransform =
     let WidgetKey = Widgets.register<CompositeTransform>()
 
     let CenterXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "CompositeTransform_CenterXY"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> CompositeTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "CompositeTransform_CenterXY" (fun _ newValueOpt node ->
+            let line = node.Target :?> CompositeTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.CenterX <- 0.
-                    line.CenterY <- 0.
-                | ValueSome (x, y) ->
-                    line.CenterX <- x
-                    line.CenterY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.CenterX <- 0.
+                line.CenterY <- 0.
+            | ValueSome(x, y) ->
+                line.CenterX <- x
+                line.CenterY <- y)
 
     let ScaleXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "CompositeTransform_ScaleXY"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> CompositeTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "CompositeTransform_ScaleXY" (fun _ newValueOpt node ->
+            let line = node.Target :?> CompositeTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.ScaleX <- 0.
-                    line.ScaleY <- 0.
-                | ValueSome (x, y) ->
-                    line.ScaleX <- x
-                    line.ScaleY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.ScaleX <- 0.
+                line.ScaleY <- 0.
+            | ValueSome(x, y) ->
+                line.ScaleX <- x
+                line.ScaleY <- y)
 
     let SkewXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "CompositeTransform_SkewXY"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> CompositeTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "CompositeTransform_SkewXY" (fun _ newValueOpt node ->
+            let line = node.Target :?> CompositeTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.SkewX <- 0.
-                    line.SkewY <- 0.
-                | ValueSome (x, y) ->
-                    line.SkewX <- x
-                    line.SkewY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.SkewX <- 0.
+                line.SkewY <- 0.
+            | ValueSome(x, y) ->
+                line.SkewX <- x
+                line.SkewY <- y)
 
     let TranslateXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "CompositeTransform_TranslateXY"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> CompositeTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "CompositeTransform_TranslateXY" (fun _ newValueOpt node ->
+            let line = node.Target :?> CompositeTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.TranslateX <- 0.
-                    line.TranslateY <- 0.
-                | ValueSome (x, y) ->
-                    line.TranslateX <- x
-                    line.TranslateY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.TranslateX <- 0.
+                line.TranslateY <- 0.
+            | ValueSome(x, y) ->
+                line.TranslateX <- x
+                line.TranslateY <- y)
 
-    let Rotation =
-        Attributes.defineBindableFloat CompositeTransform.RotationProperty
+    let Rotation = Attributes.defineBindableFloat CompositeTransform.RotationProperty
 
 [<AutoOpen>]
 module CompositeTransformBuilders =
 
     type Fabulous.XamarinForms.View with
-        static member inline CompositeTransform<'msg>
-            (
-                centerX: float,
-                centerY: float,
-                scaleX: float,
-                scaleY: float,
-                skewX: float,
-                skewY: float
-            ) =
+
+        static member inline CompositeTransform<'msg>(centerX: float, centerY: float, scaleX: float, scaleY: float, skewX: float, skewY: float) =
             WidgetBuilder<'msg, ICompositeTransform>(
                 CompositeTransform.WidgetKey,
                 CompositeTransform.CenterXY.WithValue((centerX, centerY)),

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/MatrixTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/MatrixTransform.fs
@@ -12,35 +12,22 @@ module MatrixTransform =
     let WidgetKey = Widgets.register<MatrixTransform>()
 
     let Matrix =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float * float * float * float * float)>
-            "MatrixTransform_Matrix"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> MatrixTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float * float * float * float * float)> "MatrixTransform_Matrix" (fun _ newValueOpt node ->
+            let line = node.Target :?> MatrixTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    let matrix = Matrix(0., 0., 0., 0., 0., 0.)
-                    line.Matrix <- matrix
-                | ValueSome (m11, m12, m21, m22, offsetX, offsetY) ->
-                    let matrix =
-                        Matrix(m11, m12, m21, m22, offsetX, offsetY)
+            match newValueOpt with
+            | ValueNone ->
+                let matrix = Matrix(0., 0., 0., 0., 0., 0.)
+                line.Matrix <- matrix
+            | ValueSome(m11, m12, m21, m22, offsetX, offsetY) ->
+                let matrix = Matrix(m11, m12, m21, m22, offsetX, offsetY)
 
-                    line.Matrix <- matrix)
+                line.Matrix <- matrix)
 
 [<AutoOpen>]
 module MatrixTransformBuilders =
 
     type Fabulous.XamarinForms.View with
-        static member inline MatrixTransform<'msg>
-            (
-                m11: float,
-                m12: float,
-                m21: float,
-                m22: float,
-                offsetX: float,
-                offsetY: float
-            ) =
-            WidgetBuilder<'msg, IMatrixTransform>(
-                MatrixTransform.WidgetKey,
-                MatrixTransform.Matrix.WithValue((m11, m12, m21, m22, offsetX, offsetY))
-            )
+
+        static member inline MatrixTransform<'msg>(m11: float, m12: float, m21: float, m22: float, offsetX: float, offsetY: float) =
+            WidgetBuilder<'msg, IMatrixTransform>(MatrixTransform.WidgetKey, MatrixTransform.Matrix.WithValue((m11, m12, m21, m22, offsetX, offsetY)))

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/RotateTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/RotateTransform.fs
@@ -9,19 +9,17 @@ type IRotateTransform =
 module RotateTransform =
     let WidgetKey = Widgets.register<RotateTransform>()
 
-    let Angle =
-        Attributes.defineBindableFloat RotateTransform.AngleProperty
+    let Angle = Attributes.defineBindableFloat RotateTransform.AngleProperty
 
-    let CenterX =
-        Attributes.defineBindableFloat RotateTransform.CenterXProperty
+    let CenterX = Attributes.defineBindableFloat RotateTransform.CenterXProperty
 
-    let CenterY =
-        Attributes.defineBindableFloat RotateTransform.CenterYProperty
+    let CenterY = Attributes.defineBindableFloat RotateTransform.CenterYProperty
 
 [<AutoOpen>]
 module RotateTransformBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline RotateTransform<'msg>(angle: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IRotateTransform>(
                 RotateTransform.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
@@ -10,29 +10,26 @@ module ScaleTransform =
     let WidgetKey = Widgets.register<ScaleTransform>()
 
     let ScaleXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "ScaleTransform_Scale"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> ScaleTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "ScaleTransform_Scale" (fun _ newValueOpt node ->
+            let line = node.Target :?> ScaleTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.ScaleX <- 0.
-                    line.ScaleY <- 0.
-                | ValueSome (x, y) ->
-                    line.ScaleX <- x
-                    line.ScaleY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.ScaleX <- 0.
+                line.ScaleY <- 0.
+            | ValueSome(x, y) ->
+                line.ScaleX <- x
+                line.ScaleY <- y)
 
-    let CenterX =
-        Attributes.defineBindableFloat ScaleTransform.CenterXProperty
+    let CenterX = Attributes.defineBindableFloat ScaleTransform.CenterXProperty
 
-    let CenterY =
-        Attributes.defineBindableFloat ScaleTransform.CenterYProperty
+    let CenterY = Attributes.defineBindableFloat ScaleTransform.CenterYProperty
 
 [<AutoOpen>]
 module ScaleTransformBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline ScaleTransform<'msg>(scaleX: float, scaleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IScaleTransform>(
                 ScaleTransform.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
@@ -10,29 +10,26 @@ module SkewTransform =
     let WidgetKey = Widgets.register<SkewTransform>()
 
     let AnglesXY =
-        Attributes.defineSimpleScalarWithEquality<struct (float * float)>
-            "SkewTransform_Angles"
-            (fun _ newValueOpt node ->
-                let line = node.Target :?> SkewTransform
+        Attributes.defineSimpleScalarWithEquality<struct (float * float)> "SkewTransform_Angles" (fun _ newValueOpt node ->
+            let line = node.Target :?> SkewTransform
 
-                match newValueOpt with
-                | ValueNone ->
-                    line.AngleX <- 0.
-                    line.AngleY <- 0.
-                | ValueSome (x, y) ->
-                    line.AngleX <- x
-                    line.AngleY <- y)
+            match newValueOpt with
+            | ValueNone ->
+                line.AngleX <- 0.
+                line.AngleY <- 0.
+            | ValueSome(x, y) ->
+                line.AngleX <- x
+                line.AngleY <- y)
 
-    let CenterX =
-        Attributes.defineBindableFloat ScaleTransform.CenterXProperty
+    let CenterX = Attributes.defineBindableFloat ScaleTransform.CenterXProperty
 
-    let CenterY =
-        Attributes.defineBindableFloat ScaleTransform.CenterYProperty
+    let CenterY = Attributes.defineBindableFloat ScaleTransform.CenterYProperty
 
 [<AutoOpen>]
 module SkewTransformBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline SkewTransform<'msg>(angleX: float, angleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, ISkewTransform>(
                 SkewTransform.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
@@ -12,12 +12,11 @@ module TransformGroup =
     let WidgetKey = Widgets.register<TransformGroup>()
 
     let Children =
-        Attributes.defineListWidgetCollection
-            "TransformGroup_Children"
-            (fun target -> (target :?> TransformGroup).Children :> IList<_>)
+        Attributes.defineListWidgetCollection "TransformGroup_Children" (fun target -> (target :?> TransformGroup).Children :> IList<_>)
 
 [<AutoOpen>]
 module TransformGroupBuilders =
     type Fabulous.XamarinForms.View with
+
         static member inline TransformGroup<'msg>() =
             CollectionBuilder<'msg, ITransformGroup, ITransform>(TransformGroup.WidgetKey, TransformGroup.Children)

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TranslateTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TranslateTransform.fs
@@ -9,19 +9,14 @@ type ITranslateTransform =
 module TranslateTransform =
     let WidgetKey = Widgets.register<TranslateTransform>()
 
-    let X =
-        Attributes.defineBindableFloat TranslateTransform.XProperty
+    let X = Attributes.defineBindableFloat TranslateTransform.XProperty
 
-    let Y =
-        Attributes.defineBindableFloat TranslateTransform.YProperty
+    let Y = Attributes.defineBindableFloat TranslateTransform.YProperty
 
 [<AutoOpen>]
 module TranslateTransformBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline TranslateTransform<'msg>(x: float, y: float) =
-            WidgetBuilder<'msg, ITranslateTransform>(
-                TranslateTransform.WidgetKey,
-                TranslateTransform.X.WithValue(x),
-                TranslateTransform.Y.WithValue(y)
-            )
+            WidgetBuilder<'msg, ITranslateTransform>(TranslateTransform.WidgetKey, TranslateTransform.X.WithValue(x), TranslateTransform.Y.WithValue(y))

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/_Transform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/_Transform.fs
@@ -7,5 +7,4 @@ type ITransform =
 
 module Transform =
 
-    let Value =
-        Attributes.defineBindableWithEquality<Matrix> Transform.ValueProperty
+    let Value = Attributes.defineBindableWithEquality<Matrix> Transform.ValueProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Polygon.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Polygon.fs
@@ -13,47 +13,32 @@ module Polygon =
     let WidgetKey = Widgets.register<Polygon>()
 
     let PointsString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "Polygon_PointsString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "Polygon_PointsString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Polygon.PointsProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        Polygon.PointsProperty,
-                        PointCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Polygon.PointsProperty)
+            | ValueSome string -> target.SetValue(Polygon.PointsProperty, PointCollectionConverter().ConvertFromInvariantString(string)))
 
     let PointsList =
-        Attributes.defineSimpleScalarWithEquality<Point array>
-            "Polygon_PointsList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<Point array> "Polygon_PointsList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Polygon.PointsProperty)
-                | ValueSome points ->
-                    let coll = PointCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(Polygon.PointsProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Polygon.PointsProperty)
+            | ValueSome points ->
+                let coll = PointCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(Polygon.PointsProperty, coll))
 
-    let FillRule =
-        Attributes.defineBindableEnum<FillRule> Polygon.FillRuleProperty
+    let FillRule = Attributes.defineBindableEnum<FillRule> Polygon.FillRuleProperty
 
 [<AutoOpen>]
 module PolygonBuilders =
 
     type Fabulous.XamarinForms.View with
-        static member inline Polygon<'msg>
-            (
-                points: string,
-                strokeThickness: float,
-                strokeLight: Brush,
-                ?strokeDark: Brush
-            ) =
+
+        static member inline Polygon<'msg>(points: string, strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IPolygon>(
                 Polygon.WidgetKey,
                 Polygon.PointsString.WithValue(points),
@@ -61,13 +46,7 @@ module PolygonBuilders =
                 Shape.Stroke.WithValue(AppTheme.create strokeLight strokeDark)
             )
 
-        static member inline Polygon<'msg>
-            (
-                points: Point list,
-                strokeThickness: float,
-                strokeLight: Brush,
-                ?strokeDark: Brush
-            ) =
+        static member inline Polygon<'msg>(points: Point list, strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IPolygon>(
                 Polygon.WidgetKey,
                 Polygon.PointsList.WithValue(Array.ofList points),

--- a/src/Fabulous.XamarinForms/Views/Shapes/Polyline.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Polyline.fs
@@ -13,47 +13,32 @@ module Polyline =
     let WidgetKey = Widgets.register<Polyline>()
 
     let PointsString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "Polyline_PointsString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "Polyline_PointsString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Polyline.PointsProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        Polyline.PointsProperty,
-                        PointCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Polyline.PointsProperty)
+            | ValueSome string -> target.SetValue(Polyline.PointsProperty, PointCollectionConverter().ConvertFromInvariantString(string)))
 
     let PointsList =
-        Attributes.defineSimpleScalarWithEquality<Point array>
-            "Polyline_PointsList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<Point array> "Polyline_PointsList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Polyline.PointsProperty)
-                | ValueSome points ->
-                    let coll = PointCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(Polyline.PointsProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Polyline.PointsProperty)
+            | ValueSome points ->
+                let coll = PointCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(Polyline.PointsProperty, coll))
 
-    let FillRule =
-        Attributes.defineBindableEnum<FillRule> Polyline.FillRuleProperty
+    let FillRule = Attributes.defineBindableEnum<FillRule> Polyline.FillRuleProperty
 
 [<AutoOpen>]
 module PolylineBuilders =
 
     type Fabulous.XamarinForms.View with
-        static member inline Polyline<'msg>
-            (
-                points: string,
-                strokeThickness: float,
-                strokeLight: Brush,
-                ?strokeDark: Brush
-            ) =
+
+        static member inline Polyline<'msg>(points: string, strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IPolyline>(
                 Polyline.WidgetKey,
                 Polyline.PointsString.WithValue(points),
@@ -61,13 +46,7 @@ module PolylineBuilders =
                 Shape.Stroke.WithValue(AppTheme.create strokeLight strokeDark)
             )
 
-        static member inline Polyline<'msg>
-            (
-                points: Point list,
-                strokeThickness: float,
-                strokeLight: Brush,
-                ?strokeDark: Brush
-            ) =
+        static member inline Polyline<'msg>(points: Point list, strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IPolyline>(
                 Polyline.WidgetKey,
                 Polyline.PointsList.WithValue(Array.ofList points),

--- a/src/Fabulous.XamarinForms/Views/Shapes/Rectangle.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Rectangle.fs
@@ -12,16 +12,15 @@ module Rectangle =
 
     let WidgetKey = Widgets.register<Rectangle>()
 
-    let RadiusX =
-        Attributes.defineBindableFloat Rectangle.RadiusXProperty
+    let RadiusX = Attributes.defineBindableFloat Rectangle.RadiusXProperty
 
-    let RadiusY =
-        Attributes.defineBindableFloat Rectangle.RadiusYProperty
+    let RadiusY = Attributes.defineBindableFloat Rectangle.RadiusYProperty
 
 [<AutoOpen>]
 module RectangleBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline Rectangle<'msg>(strokeThickness: float, strokeLight: Brush, ?strokeDark: Brush) =
             WidgetBuilder<'msg, IRectangle>(
                 Rectangle.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
@@ -11,17 +11,13 @@ type IArcSegment =
 module ArcSegment =
     let WidgetKey = Widgets.register<ArcSegment>()
 
-    let IsLargeArc =
-        Attributes.defineBindableBool ArcSegment.IsLargeArcProperty
+    let IsLargeArc = Attributes.defineBindableBool ArcSegment.IsLargeArcProperty
 
-    let Point =
-        Attributes.defineBindableWithEquality<Point> ArcSegment.SizeProperty
+    let Point = Attributes.defineBindableWithEquality<Point> ArcSegment.SizeProperty
 
-    let RotationAngle =
-        Attributes.defineBindableFloat ArcSegment.RotationAngleProperty
+    let RotationAngle = Attributes.defineBindableFloat ArcSegment.RotationAngleProperty
 
-    let Size =
-        Attributes.defineBindableWithEquality<Size> ArcSegment.SizeProperty
+    let Size = Attributes.defineBindableWithEquality<Size> ArcSegment.SizeProperty
 
     let SweepDirection =
         Attributes.defineBindableEnum<SweepDirection> ArcSegment.SweepDirectionProperty
@@ -30,12 +26,9 @@ module ArcSegment =
 module ArcSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline ArcSegment<'msg>(point: Point, size: Size) =
-            WidgetBuilder<'msg, IArcSegment>(
-                ArcSegment.WidgetKey,
-                ArcSegment.Point.WithValue(point),
-                ArcSegment.Size.WithValue(size)
-            )
+            WidgetBuilder<'msg, IArcSegment>(ArcSegment.WidgetKey, ArcSegment.Point.WithValue(point), ArcSegment.Size.WithValue(size))
 
 [<Extension>]
 type ArcSegmentModifiers =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/BezierSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/BezierSegment.fs
@@ -23,6 +23,7 @@ module BezierSegment =
 module BezierSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline BezierSegment<'msg>(point1: Point, point2: Point, point3: Point) =
             WidgetBuilder<'msg, IBezierSegment>(
                 BezierSegment.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/LineSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/LineSegment.fs
@@ -10,12 +10,12 @@ type ILineSegment =
 module LineSegment =
     let WidgetKey = Widgets.register<LineSegment>()
 
-    let Point =
-        Attributes.defineBindableWithEquality<Point> LineSegment.PointProperty
+    let Point = Attributes.defineBindableWithEquality<Point> LineSegment.PointProperty
 
 [<AutoOpen>]
 module LineSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline LineSegment<'msg>(point: Point) =
             WidgetBuilder<'msg, ILineSegment>(LineSegment.WidgetKey, LineSegment.Point.WithValue(point))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
@@ -13,32 +13,25 @@ module PathFigure =
     let WidgetKey = Widgets.register<PathFigure>()
 
     let Segments =
-        Attributes.defineListWidgetCollection
-            "PathGeometry_Segments"
-            (fun target -> (target :?> PathFigure).Segments :> IList<_>)
+        Attributes.defineListWidgetCollection "PathGeometry_Segments" (fun target -> (target :?> PathFigure).Segments :> IList<_>)
 
     let StartPoint =
         Attributes.defineBindableWithEquality<Point> PathFigure.StartPointProperty
 
-    let IsClosed =
-        Attributes.defineBindableBool PathFigure.IsClosedProperty
+    let IsClosed = Attributes.defineBindableBool PathFigure.IsClosedProperty
 
-    let IsFilled =
-        Attributes.defineBindableBool PathFigure.IsFilledProperty
+    let IsFilled = Attributes.defineBindableBool PathFigure.IsFilledProperty
 
 [<AutoOpen>]
 module PathFigureBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline PathFigure<'msg>(?start: Point) =
             match start with
             | None -> CollectionBuilder<'msg, IPathFigure, IPathSegment>(PathFigure.WidgetKey, PathFigure.Segments)
             | Some start ->
-                CollectionBuilder<'msg, IPathFigure, IPathSegment>(
-                    PathFigure.WidgetKey,
-                    PathFigure.Segments,
-                    PathFigure.StartPoint.WithValue(start)
-                )
+                CollectionBuilder<'msg, IPathFigure, IPathSegment>(PathFigure.WidgetKey, PathFigure.Segments, PathFigure.StartPoint.WithValue(start))
 
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyBezierSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyBezierSegment.fs
@@ -11,45 +11,31 @@ module PolyBezierSegment =
     let WidgetKey = Widgets.register<PolyBezierSegment>()
 
     let PointsString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "PolyBezierSegment_PointsString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "PolyBezierSegment_PointsString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyBezierSegment.PointsProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        PolyBezierSegment.PointsProperty,
-                        PointCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyBezierSegment.PointsProperty)
+            | ValueSome string -> target.SetValue(PolyBezierSegment.PointsProperty, PointCollectionConverter().ConvertFromInvariantString(string)))
 
     let PointsList =
-        Attributes.defineSimpleScalarWithEquality<Point array>
-            "PolyBezierSegment_PointsList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<Point array> "PolyBezierSegment_PointsList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyBezierSegment.PointsProperty)
-                | ValueSome points ->
-                    let coll = PointCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(PolyBezierSegment.PointsProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyBezierSegment.PointsProperty)
+            | ValueSome points ->
+                let coll = PointCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(PolyBezierSegment.PointsProperty, coll))
 
 [<AutoOpen>]
 module PolyBezierSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline PolyBezierSegment<'msg>(points: string) =
-            WidgetBuilder<'msg, IPolyBezierSegment>(
-                PolyBezierSegment.WidgetKey,
-                PolyBezierSegment.PointsString.WithValue(points)
-            )
+            WidgetBuilder<'msg, IPolyBezierSegment>(PolyBezierSegment.WidgetKey, PolyBezierSegment.PointsString.WithValue(points))
 
         static member inline PolyBezierSegment<'msg>(points: Point list) =
-            WidgetBuilder<'msg, IPolyBezierSegment>(
-                PolyBezierSegment.WidgetKey,
-                PolyBezierSegment.PointsList.WithValue(Array.ofList points)
-            )
+            WidgetBuilder<'msg, IPolyBezierSegment>(PolyBezierSegment.WidgetKey, PolyBezierSegment.PointsList.WithValue(Array.ofList points))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyLineSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyLineSegment.fs
@@ -11,45 +11,31 @@ module PolyLineSegment =
     let WidgetKey = Widgets.register<PolyLineSegment>()
 
     let PointsString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "PolyLineSegment_PointsString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "PolyLineSegment_PointsString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyLineSegment.PointsProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        PolyLineSegment.PointsProperty,
-                        PointCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyLineSegment.PointsProperty)
+            | ValueSome string -> target.SetValue(PolyLineSegment.PointsProperty, PointCollectionConverter().ConvertFromInvariantString(string)))
 
     let PointsList =
-        Attributes.defineSimpleScalarWithEquality<Point array>
-            "PolyLineSegment_PointsList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<Point array> "PolyLineSegment_PointsList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyLineSegment.PointsProperty)
-                | ValueSome points ->
-                    let coll = PointCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(PolyLineSegment.PointsProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyLineSegment.PointsProperty)
+            | ValueSome points ->
+                let coll = PointCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(PolyLineSegment.PointsProperty, coll))
 
 [<AutoOpen>]
 module PolyLineSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline PolyLineSegment<'msg>(points: string) =
-            WidgetBuilder<'msg, IPolyLineSegment>(
-                PolyLineSegment.WidgetKey,
-                PolyLineSegment.PointsString.WithValue(points)
-            )
+            WidgetBuilder<'msg, IPolyLineSegment>(PolyLineSegment.WidgetKey, PolyLineSegment.PointsString.WithValue(points))
 
         static member inline PolyLineSegment<'msg>(points: Point list) =
-            WidgetBuilder<'msg, IPolyLineSegment>(
-                PolyLineSegment.WidgetKey,
-                PolyLineSegment.PointsList.WithValue(Array.ofList points)
-            )
+            WidgetBuilder<'msg, IPolyLineSegment>(PolyLineSegment.WidgetKey, PolyLineSegment.PointsList.WithValue(Array.ofList points))

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyQuadraticBezierSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PolyQuadraticBezierSegment.fs
@@ -8,46 +8,34 @@ type IPolyQuadraticBezierSegment =
     inherit IPathSegment
 
 module PolyQuadraticBezierSegment =
-    let WidgetKey =
-        Widgets.register<PolyQuadraticBezierSegment>()
+    let WidgetKey = Widgets.register<PolyQuadraticBezierSegment>()
 
     let PointsString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "PolyQuadraticBezierSegment_PointsString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "PolyQuadraticBezierSegment_PointsString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyQuadraticBezierSegment.PointsProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        PolyQuadraticBezierSegment.PointsProperty,
-                        PointCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyQuadraticBezierSegment.PointsProperty)
+            | ValueSome string -> target.SetValue(PolyQuadraticBezierSegment.PointsProperty, PointCollectionConverter().ConvertFromInvariantString(string)))
 
     let PointsList =
-        Attributes.defineSimpleScalarWithEquality<Point array>
-            "PolyQuadraticBezierSegment_PointsList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<Point array> "PolyQuadraticBezierSegment_PointsList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(PolyQuadraticBezierSegment.PointsProperty)
-                | ValueSome points ->
-                    let coll = PointCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(PolyQuadraticBezierSegment.PointsProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(PolyQuadraticBezierSegment.PointsProperty)
+            | ValueSome points ->
+                let coll = PointCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(PolyQuadraticBezierSegment.PointsProperty, coll))
 
 [<AutoOpen>]
 module PolyQuadraticBezierSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline PolyQuadraticBezierSegment<'msg>(points: string) =
-            WidgetBuilder<'msg, IPolyQuadraticBezierSegment>(
-                PolyQuadraticBezierSegment.WidgetKey,
-                PolyQuadraticBezierSegment.PointsString.WithValue(points)
-            )
+            WidgetBuilder<'msg, IPolyQuadraticBezierSegment>(PolyQuadraticBezierSegment.WidgetKey, PolyQuadraticBezierSegment.PointsString.WithValue(points))
 
         static member inline PolyQuadraticBezierSegment<'msg>(points: Point list) =
             WidgetBuilder<'msg, IPolyQuadraticBezierSegment>(

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/QuadraticBezierSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/QuadraticBezierSegment.fs
@@ -8,8 +8,7 @@ type IQuadraticBezierSegment =
     inherit IPathSegment
 
 module QuadraticBezierSegment =
-    let WidgetKey =
-        Widgets.register<QuadraticBezierSegment>()
+    let WidgetKey = Widgets.register<QuadraticBezierSegment>()
 
     let Point1 =
         Attributes.defineBindableWithEquality<Point> QuadraticBezierSegment.Point1Property
@@ -21,6 +20,7 @@ module QuadraticBezierSegment =
 module QuadraticBezierSegmentBuilders =
 
     type Fabulous.XamarinForms.View with
+
         static member inline QuadraticBezierSegment<'msg>(point1: Point, point2: Point) =
             WidgetBuilder<'msg, IQuadraticBezierSegment>(
                 QuadraticBezierSegment.WidgetKey,

--- a/src/Fabulous.XamarinForms/Views/Shapes/_Shape.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/_Shape.fs
@@ -10,45 +10,32 @@ type IShape =
 
 module Shape =
 
-    let Fill =
-        Attributes.defineBindableAppTheme<Brush> Shape.FillProperty
+    let Fill = Attributes.defineBindableAppTheme<Brush> Shape.FillProperty
 
-    let Stroke =
-        Attributes.defineBindableAppTheme<Brush> Shape.StrokeProperty
+    let Stroke = Attributes.defineBindableAppTheme<Brush> Shape.StrokeProperty
 
-    let StrokeThickness =
-        Attributes.defineBindableFloat Shape.StrokeThicknessProperty
+    let StrokeThickness = Attributes.defineBindableFloat Shape.StrokeThicknessProperty
 
     let StrokeDashArrayString =
-        Attributes.defineSimpleScalarWithEquality<string>
-            "Shape_StrokeDashArrayString"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<string> "Shape_StrokeDashArrayString" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Shape.StrokeDashArrayProperty)
-                | ValueSome string ->
-                    target.SetValue(
-                        Shape.StrokeDashArrayProperty,
-                        DoubleCollectionConverter()
-                            .ConvertFromInvariantString(string)
-                    ))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Shape.StrokeDashArrayProperty)
+            | ValueSome string -> target.SetValue(Shape.StrokeDashArrayProperty, DoubleCollectionConverter().ConvertFromInvariantString(string)))
 
     let StrokeDashArrayList =
-        Attributes.defineSimpleScalarWithEquality<float array>
-            "Shape_StrokeDashArrayList"
-            (fun _ newValueOpt node ->
-                let target = node.Target :?> BindableObject
+        Attributes.defineSimpleScalarWithEquality<float array> "Shape_StrokeDashArrayList" (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
 
-                match newValueOpt with
-                | ValueNone -> target.ClearValue(Shape.StrokeDashArrayProperty)
-                | ValueSome points ->
-                    let coll = DoubleCollection()
-                    points |> Array.iter coll.Add
-                    target.SetValue(Shape.StrokeDashArrayProperty, coll))
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(Shape.StrokeDashArrayProperty)
+            | ValueSome points ->
+                let coll = DoubleCollection()
+                points |> Array.iter coll.Add
+                target.SetValue(Shape.StrokeDashArrayProperty, coll))
 
-    let StrokeDashOffset =
-        Attributes.defineBindableFloat Shape.StrokeDashOffsetProperty
+    let StrokeDashOffset = Attributes.defineBindableFloat Shape.StrokeDashOffsetProperty
 
     let StrokeLineCap =
         Attributes.defineBindableWithEquality<PenLineCap> Shape.StrokeLineCapProperty
@@ -56,11 +43,9 @@ module Shape =
     let StrokeLineJoin =
         Attributes.defineBindableWithEquality<PenLineJoin> Shape.StrokeLineJoinProperty
 
-    let StrokeMiterLimit =
-        Attributes.defineBindableFloat Shape.StrokeMiterLimitProperty
+    let StrokeMiterLimit = Attributes.defineBindableFloat Shape.StrokeMiterLimitProperty
 
-    let Aspect =
-        Attributes.defineBindableWithEquality<Stretch> Shape.AspectProperty
+    let Aspect = Attributes.defineBindableWithEquality<Stretch> Shape.AspectProperty
 
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/_View.fs
+++ b/src/Fabulous.XamarinForms/Views/_View.fs
@@ -14,13 +14,10 @@ module XFView =
     let VerticalOptions =
         Attributes.defineSmallBindable<LayoutOptions> View.VerticalOptionsProperty SmallScalars.LayoutOptions.decode
 
-    let Margin =
-        Attributes.defineBindableWithEquality<Thickness> View.MarginProperty
+    let Margin = Attributes.defineBindableWithEquality<Thickness> View.MarginProperty
 
     let GestureRecognizers =
-        Attributes.defineListWidgetCollection<IGestureRecognizer>
-            "View_GestureRecognizers"
-            (fun target -> (target :?> View).GestureRecognizers)
+        Attributes.defineListWidgetCollection<IGestureRecognizer> "View_GestureRecognizers" (fun target -> (target :?> View).GestureRecognizers)
 
 [<Extension>]
 type ViewModifiers =
@@ -134,18 +131,9 @@ type ViewModifiers =
         ViewModifiers.margin(this, Thickness(value))
 
     [<Extension>]
-    static member inline margin
-        (
-            this: WidgetBuilder<'msg, #IView>,
-            left: float,
-            top: float,
-            right: float,
-            bottom: float
-        ) =
+    static member inline margin(this: WidgetBuilder<'msg, #IView>, left: float, top: float, right: float, bottom: float) =
         ViewModifiers.margin(this, Thickness(left, top, right, bottom))
 
     [<Extension>]
     static member inline gestureRecognizers<'msg, 'marker when 'marker :> IView>(this: WidgetBuilder<'msg, 'marker>) =
-        WidgetHelpers.buildAttributeCollection<'msg, 'marker, Fabulous.XamarinForms.IGestureRecognizer>
-            XFView.GestureRecognizers
-            this
+        WidgetHelpers.buildAttributeCollection<'msg, 'marker, Fabulous.XamarinForms.IGestureRecognizer> XFView.GestureRecognizers this

--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -34,11 +34,7 @@ type RotateToData =
       Easing: Easing }
 
 module VisualElementUpdaters =
-    let updateVisualElementFocus
-        (oldValueOpt: ValueEventData<bool, bool> voption)
-        (newValueOpt: ValueEventData<bool, bool> voption)
-        (node: IViewNode)
-        =
+    let updateVisualElementFocus (oldValueOpt: ValueEventData<bool, bool> voption) (newValueOpt: ValueEventData<bool, bool> voption) (node: IViewNode) =
         let target = node.Target :?> VisualElement
 
         let onEventName = "Focus_On"
@@ -74,8 +70,7 @@ module VisualElementUpdaters =
             | ValueSome handler -> offEvent.RemoveHandler(handler)
 
             // Change the focus state, except if the old value was the same
-            if oldValueOpt.IsSome
-               && oldValueOpt.Value.Value = curr.Value then
+            if oldValueOpt.IsSome && oldValueOpt.Value.Value = curr.Value then
                 ()
             else
                 match struct (curr.Value, target.IsFocused) with
@@ -85,29 +80,25 @@ module VisualElementUpdaters =
 
             // Set the new event handlers
             let onHandler =
-                EventHandler<FocusEventArgs>
-                    (fun sender args ->
-                        let r = curr.Event true
-                        Dispatcher.dispatch node r)
+                EventHandler<FocusEventArgs>(fun sender args ->
+                    let r = curr.Event true
+                    Dispatcher.dispatch node r)
 
             node.SetHandler(onEventName, ValueSome onHandler)
             onEvent.AddHandler(onHandler)
 
             let offHandler =
-                EventHandler<FocusEventArgs>
-                    (fun sender args ->
-                        let r = curr.Event false
-                        Dispatcher.dispatch node r)
+                EventHandler<FocusEventArgs>(fun sender args ->
+                    let r = curr.Event false
+                    Dispatcher.dispatch node r)
 
             node.SetHandler(offEventName, ValueSome offHandler)
             offEvent.AddHandler(offHandler)
 
 module VisualElement =
-    let AnchorX =
-        Attributes.defineBindableFloat VisualElement.AnchorXProperty
+    let AnchorX = Attributes.defineBindableFloat VisualElement.AnchorXProperty
 
-    let AnchorY =
-        Attributes.defineBindableFloat VisualElement.AnchorYProperty
+    let AnchorY = Attributes.defineBindableFloat VisualElement.AnchorYProperty
 
     let BackgroundColor =
         Attributes.defineBindableAppThemeColor VisualElement.BackgroundColorProperty
@@ -115,8 +106,7 @@ module VisualElement =
     let Background =
         Attributes.defineBindableAppTheme<Brush> VisualElement.BackgroundProperty
 
-    let Clip =
-        Attributes.defineBindableWidget VisualElement.ClipProperty
+    let Clip = Attributes.defineBindableWidget VisualElement.ClipProperty
 
     let FlowDirection =
         Attributes.defineBindableEnum<FlowDirection> VisualElement.FlowDirectionProperty
@@ -124,20 +114,16 @@ module VisualElement =
     let HeightRequest =
         Attributes.defineBindableFloat VisualElement.HeightRequestProperty
 
-    let WidthRequest =
-        Attributes.defineBindableFloat VisualElement.WidthRequestProperty
+    let WidthRequest = Attributes.defineBindableFloat VisualElement.WidthRequestProperty
 
     let InputTransparent =
         Attributes.defineBindableBool VisualElement.InputTransparentProperty
 
-    let IsEnabled =
-        Attributes.defineBindableBool VisualElement.IsEnabledProperty
+    let IsEnabled = Attributes.defineBindableBool VisualElement.IsEnabledProperty
 
-    let IsTabStop =
-        Attributes.defineBindableBool VisualElement.IsTabStopProperty
+    let IsTabStop = Attributes.defineBindableBool VisualElement.IsTabStopProperty
 
-    let IsVisible =
-        Attributes.defineBindableBool VisualElement.IsVisibleProperty
+    let IsVisible = Attributes.defineBindableBool VisualElement.IsVisibleProperty
 
     let MinimumHeightRequest =
         Attributes.defineBindableFloat VisualElement.MinimumHeightRequestProperty
@@ -145,146 +131,95 @@ module VisualElement =
     let MinimumWidthRequest =
         Attributes.defineBindableFloat VisualElement.MinimumWidthRequestProperty
 
-    let Opacity =
-        Attributes.defineBindableFloat VisualElement.OpacityProperty
+    let Opacity = Attributes.defineBindableFloat VisualElement.OpacityProperty
 
-    let TabIndex =
-        Attributes.defineBindableInt VisualElement.TabIndexProperty
+    let TabIndex = Attributes.defineBindableInt VisualElement.TabIndexProperty
 
     let Visual =
         Attributes.defineBindableWithEquality<IVisual> VisualElement.VisualProperty
 
     [<Obsolete("Use FocusWithEvent instead")>]
     let Focused =
-        Attributes.defineEvent<FocusEventArgs>
-            "VisualElement_Focused"
-            (fun target -> (target :?> VisualElement).Focused)
+        Attributes.defineEvent<FocusEventArgs> "VisualElement_Focused" (fun target -> (target :?> VisualElement).Focused)
 
     [<Obsolete("Use FocusWithEvent instead")>]
     let Unfocused =
-        Attributes.defineEvent<FocusEventArgs>
-            "VisualElement_Unfocused"
-            (fun target -> (target :?> VisualElement).Unfocused)
+        Attributes.defineEvent<FocusEventArgs> "VisualElement_Unfocused" (fun target -> (target :?> VisualElement).Unfocused)
 
     let TranslateTo =
-        Attributes.defineSimpleScalarWithEquality<TranslateToData>
-            "View_TranslateTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<TranslateToData> "View_TranslateTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone ->
-                    view.TranslateTo(0., 0., uint 0, Easing.Linear)
-                    |> ignore
-                | ValueSome data ->
-                    view.TranslateTo(data.X, data.Y, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.TranslateTo(0., 0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.TranslateTo(data.X, data.Y, data.AnimationDuration, data.Easing) |> ignore)
 
-    let TranslationX =
-        Attributes.defineBindableFloat VisualElement.TranslationXProperty
+    let TranslationX = Attributes.defineBindableFloat VisualElement.TranslationXProperty
 
-    let TranslationY =
-        Attributes.defineBindableFloat VisualElement.TranslationYProperty
+    let TranslationY = Attributes.defineBindableFloat VisualElement.TranslationYProperty
 
     let ScaleTo =
-        Attributes.defineSimpleScalarWithEquality<ScaleToData>
-            "View_ScaleTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<ScaleToData> "View_ScaleTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone -> view.ScaleTo(1., uint 0, Easing.Linear) |> ignore
-                | ValueSome data ->
-                    view.ScaleTo(data.Scale, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.ScaleTo(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
-    let ScaleX =
-        Attributes.defineBindableFloat VisualElement.ScaleXProperty
+    let ScaleX = Attributes.defineBindableFloat VisualElement.ScaleXProperty
 
     let ScaleXTo =
-        Attributes.defineSimpleScalarWithEquality<ScaleToData>
-            "View_ScaleXTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<ScaleToData> "View_ScaleXTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone -> view.ScaleXTo(1., uint 0, Easing.Linear) |> ignore
-                | ValueSome data ->
-                    view.ScaleXTo(data.Scale, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.ScaleXTo(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleXTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
-    let ScaleY =
-        Attributes.defineBindableFloat VisualElement.ScaleYProperty
+    let ScaleY = Attributes.defineBindableFloat VisualElement.ScaleYProperty
 
     let ScaleYTo =
-        Attributes.defineSimpleScalarWithEquality<ScaleToData>
-            "View_ScaleYTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<ScaleToData> "View_ScaleYTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone -> view.ScaleYTo(1., uint 0, Easing.Linear) |> ignore
-                | ValueSome data ->
-                    view.ScaleYTo(data.Scale, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.ScaleYTo(1., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.ScaleYTo(data.Scale, data.AnimationDuration, data.Easing) |> ignore)
 
     let FadeTo =
-        Attributes.defineSimpleScalarWithEquality<FadeToData>
-            "View_FadeTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<FadeToData> "View_FadeTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone -> view.FadeTo(0., uint 0, Easing.Linear) |> ignore
-                | ValueSome data ->
-                    view.FadeTo(data.Opacity, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.FadeTo(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.FadeTo(data.Opacity, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateTo =
-        Attributes.defineSimpleScalarWithEquality<RotateToData>
-            "View_RotateTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<RotateToData> "View_RotateTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone -> view.RotateTo(0., uint 0, Easing.Linear) |> ignore
-                | ValueSome data ->
-                    view.RotateTo(data.Rotation, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.RotateTo(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateXTo =
-        Attributes.defineSimpleScalarWithEquality<RotateToData>
-            "View_RotateXTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<RotateToData> "View_RotateXTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone ->
-                    view.RotateXTo(0., uint 0, Easing.Linear)
-                    |> ignore
-                | ValueSome data ->
-                    view.RotateXTo(data.Rotation, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.RotateXTo(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateXTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let RotateYTo =
-        Attributes.defineSimpleScalarWithEquality<RotateToData>
-            "View_RotateYTo"
-            (fun _ newValueOpt node ->
-                let view = node.Target :?> View
+        Attributes.defineSimpleScalarWithEquality<RotateToData> "View_RotateYTo" (fun _ newValueOpt node ->
+            let view = node.Target :?> View
 
-                match newValueOpt with
-                | ValueNone ->
-                    view.RotateYTo(0., uint 0, Easing.Linear)
-                    |> ignore
-                | ValueSome data ->
-                    view.RotateYTo(data.Rotation, data.AnimationDuration, data.Easing)
-                    |> ignore)
+            match newValueOpt with
+            | ValueNone -> view.RotateYTo(0., uint 0, Easing.Linear) |> ignore
+            | ValueSome data -> view.RotateYTo(data.Rotation, data.AnimationDuration, data.Easing) |> ignore)
 
     let FocusWithEvent =
-        Attributes.defineSimpleScalar
-            "VisualElement_FocusWithEvent"
-            ScalarAttributeComparers.noCompare
-            VisualElementUpdaters.updateVisualElementFocus
+        Attributes.defineSimpleScalar "VisualElement_FocusWithEvent" ScalarAttributeComparers.noCompare VisualElementUpdaters.updateVisualElementFocus
 
 [<Extension>]
 type VisualElementModifiers =
@@ -331,17 +266,8 @@ type VisualElementModifiers =
     /// <param name="isFocused">The focus state</param>
     /// <param name="onFocusChange">The message to dispatch when the focus state changes</param>
     [<Extension>]
-    static member inline focus
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            isFocused: bool,
-            onFocusChanged: bool -> 'msg
-        ) =
-        this.AddScalar(
-            VisualElement.FocusWithEvent.WithValue(
-                ValueEventData.create isFocused (fun args -> onFocusChanged args |> box)
-            )
-        )
+    static member inline focus(this: WidgetBuilder<'msg, #IVisualElement>, isFocused: bool, onFocusChanged: bool -> 'msg) =
+        this.AddScalar(VisualElement.FocusWithEvent.WithValue(ValueEventData.create isFocused (fun args -> onFocusChanged args |> box)))
 
     /// <summary>Sets the height of the element.</summary>
     [<Extension>]
@@ -437,13 +363,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline fadeTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            opacity: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline fadeTo(this: WidgetBuilder<'msg, #IVisualElement>, opacity: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.FadeTo.WithValue(
                 { Opacity = opacity
@@ -457,13 +377,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline rotateTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            rotation: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline rotateTo(this: WidgetBuilder<'msg, #IVisualElement>, rotation: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.RotateTo.WithValue(
                 { Rotation = rotation
@@ -477,13 +391,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline rotateXTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            rotation: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline rotateXTo(this: WidgetBuilder<'msg, #IVisualElement>, rotation: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.RotateXTo.WithValue(
                 { Rotation = rotation
@@ -497,13 +405,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline rotateYTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            rotation: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline rotateYTo(this: WidgetBuilder<'msg, #IVisualElement>, rotation: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.RotateYTo.WithValue(
                 { Rotation = rotation
@@ -523,13 +425,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline scaleTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            scale: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline scaleTo(this: WidgetBuilder<'msg, #IVisualElement>, scale: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.ScaleTo.WithValue(
                 { Scale = scale
@@ -543,13 +439,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline scaleXTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            scale: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline scaleXTo(this: WidgetBuilder<'msg, #IVisualElement>, scale: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.ScaleXTo.WithValue(
                 { Scale = scale
@@ -569,13 +459,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The time, in milliseconds, over which to animate the transition. The default is 250.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline scaleYTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            scale: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline scaleYTo(this: WidgetBuilder<'msg, #IVisualElement>, scale: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.ScaleYTo.WithValue(
                 { Scale = scale
@@ -590,14 +474,7 @@ type VisualElementAnimationModifiers =
     /// <param name="duration">The duration of the animation in milliseconds.</param>
     /// <param name="easing">The easing of the animation.</param>
     [<Extension>]
-    static member inline translateTo
-        (
-            this: WidgetBuilder<'msg, #IVisualElement>,
-            x: float,
-            y: float,
-            duration: int,
-            easing: Easing
-        ) =
+    static member inline translateTo(this: WidgetBuilder<'msg, #IVisualElement>, x: float, y: float, duration: int, easing: Easing) =
         this.AddScalar(
             VisualElement.TranslateTo.WithValue(
                 { X = x

--- a/src/Fabulous.XamarinForms/VirtualizedCollection.fs
+++ b/src/Fabulous.XamarinForms/VirtualizedCollection.fs
@@ -25,25 +25,21 @@ module BindableHelpers =
 /// Create a DataTemplate for a specific root type (TextCell, ViewCell, etc.)
 /// that listen for BindingContext change to apply the Widget content to the cell
 type WidgetDataTemplate(parent: IViewNode, ``type``: Type, templateFn: obj -> Widget) =
-    inherit DataTemplate(fun () ->
-        let bindableObject =
-            Activator.CreateInstance ``type`` :?> BindableObject
+    inherit
+        DataTemplate(fun () ->
+            let bindableObject = Activator.CreateInstance ``type`` :?> BindableObject
 
-        let viewNode =
-            ViewNode(Some parent, parent.TreeContext, WeakReference(bindableObject))
+            let viewNode =
+                ViewNode(Some parent, parent.TreeContext, WeakReference(bindableObject))
 
-        bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
+            bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
 
-        let onBindingContextChanged =
-            BindableHelpers.createOnBindingContextChanged
-                parent.TreeContext.CanReuseView
-                parent.TreeContext.GetViewNode
-                templateFn
-                bindableObject
+            let onBindingContextChanged =
+                BindableHelpers.createOnBindingContextChanged parent.TreeContext.CanReuseView parent.TreeContext.GetViewNode templateFn bindableObject
 
-        bindableObject.BindingContextChanged.Add(fun _ -> onBindingContextChanged())
+            bindableObject.BindingContextChanged.Add(fun _ -> onBindingContextChanged())
 
-        bindableObject :> obj)
+            bindableObject :> obj)
 
 /// Redirect to the right type of DataTemplate based on the target type of the current widget cell
 type WidgetDataTemplateSelector internal (node: IViewNode, templateFn: obj -> Widget) =
@@ -60,8 +56,7 @@ type WidgetDataTemplateSelector internal (node: IViewNode, templateFn: obj -> Wi
         match cache.TryGetValue(targetType) with
         | true, dataTemplate -> dataTemplate
         | false, _ ->
-            let dataTemplate =
-                WidgetDataTemplate(node, targetType, templateFn) :> DataTemplate
+            let dataTemplate = WidgetDataTemplate(node, targetType, templateFn) :> DataTemplate
 
             cache.Add(targetType, dataTemplate)
             dataTemplate

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -15,9 +15,7 @@ type View =
     end
 
 module Widgets =
-    let registerWithAdditionalSetup<'T when 'T :> Xamarin.Forms.BindableObject and 'T: (new: unit -> 'T)>
-        (additionalSetup: 'T -> IViewNode -> unit)
-        =
+    let registerWithAdditionalSetup<'T when 'T :> Xamarin.Forms.BindableObject and 'T: (new: unit -> 'T)> (additionalSetup: 'T -> IViewNode -> unit) =
         let key = WidgetDefinitionStore.getNextKey()
 
         let definition =
@@ -25,26 +23,25 @@ module Widgets =
               Name = typeof<'T>.Name
               TargetType = typeof<'T>
               CreateView =
-                  fun (widget, treeContext, parentNode) ->
-                      treeContext.Logger.Debug("Creating view for {0}", typeof<'T>.Name)
+                fun (widget, treeContext, parentNode) ->
+                    treeContext.Logger.Debug("Creating view for {0}", typeof<'T>.Name)
 
-                      let view = new 'T()
-                      let weakReference = WeakReference(view)
+                    let view = new 'T()
+                    let weakReference = WeakReference(view)
 
-                      let parentNode =
-                          match parentNode with
-                          | ValueNone -> None
-                          | ValueSome node -> Some node
+                    let parentNode =
+                        match parentNode with
+                        | ValueNone -> None
+                        | ValueSome node -> Some node
 
-                      let node =
-                          ViewNode(parentNode, treeContext, weakReference)
+                    let node = ViewNode(parentNode, treeContext, weakReference)
 
-                      ViewNode.set node view
+                    ViewNode.set node view
 
-                      additionalSetup view node
+                    additionalSetup view node
 
-                      Reconciler.update treeContext.CanReuseView ValueNone widget node
-                      struct (node :> IViewNode, box view) }
+                    Reconciler.update treeContext.CanReuseView ValueNone widget node
+                    struct (node :> IViewNode, box view) }
 
         WidgetDefinitionStore.set key definition
         key
@@ -54,11 +51,9 @@ module Widgets =
 
 module WidgetHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, 'marker>>) =
-        items
-        |> Seq.map(fun item -> item.Compile())
-        |> Seq.toArray
+        items |> Seq.map(fun item -> item.Compile()) |> Seq.toArray
 
-    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
+    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute[]) =
         WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), ValueSome attrs, ValueNone))
 
     let inline buildAttributeCollection<'msg, 'marker, 'item>

--- a/templates/README.md
+++ b/templates/README.md
@@ -4,46 +4,12 @@ Fabulous.XamarinForms brings the great development experience of Fabulous to Xam
 
 Deploy to any platform supported by Xamarin.Forms, such as Android, iOS, macOS, Windows, Linux and more!
 
-```fs
-/// A simple Counter app
-
-type Model =
-    { Count: int }
-
-type Msg =
-    | Increment
-    | Decrement
-
-let init () =
-    { Count = 0 }
-
-let update msg model =
-    match msg with
-    | Increment -> { model with Count = model.Count + 1 }
-    | Decrement -> { model with Count = model.Count - 1 }
-
-let view model =
-    Application(
-        ContentPage(
-            "Counter app",
-            VStack(spacing = 16.) {
-                Image(Aspect.AspectFit, "fabulous.png")
-
-                Label($"Count is {model.Count}")
-
-                Button("Increment", Increment)
-                Button("Decrement", Decrement)
-            }
-        )
-    )
-```
-
 ## How to use the templates
 
 Using the dotnet CLI, install the templates:
 
 ```sh
-dotnet new -i Fabulous.XamarinForms.Templates
+dotnet new install Fabulous.XamarinForms.Templates
 ```
 
 Then, you will be able to create new Fabulous.XamarinForms projects with `dotnet new`:
@@ -57,3 +23,7 @@ If you're using Visual Studio on Windows, prefer the `fabulous-xf-vswin` templat
 ```sh
 dotnet new fabulous-xf-vswin -n MyApp
 ```
+
+### Documentation
+
+Documentation can be found at https://docs.fabulous.dev/v2/xamarin.forms

--- a/templates/content/blank-vswin/NewApp.Android/MainActivity.fs
+++ b/templates/content/blank-vswin/NewApp.Android/MainActivity.fs
@@ -18,8 +18,7 @@ open Xamarin.Forms.Platform.Android
            Icon = "@drawable/icon",
            Theme = "@style/MainTheme",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation))>]
+           ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -34,11 +33,6 @@ type MainActivity() =
         Xamarin.Forms.Forms.Init(this, bundle)
         this.LoadApplication(Program.startApplication App.program)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Android.Content.PM.Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Android.Content.PM.Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/templates/content/blank-vswin/NewApp/App.fs
+++ b/templates/content/blank-vswin/NewApp/App.fs
@@ -29,12 +29,11 @@ module App =
                         .centerTextHorizontal()
 
                     (VStack() {
-                        Label($"Count is {model.Count}")
-                            .centerTextHorizontal()
+                        Label($"Count is {model.Count}").centerTextHorizontal()
 
                         Button("Increment", Increment)
                         Button("Decrement", Decrement)
-                     })
+                    })
                         .centerVertical(expand = true)
                 }
             )

--- a/templates/content/blank/NewApp.Android/MainActivity.fs
+++ b/templates/content/blank/NewApp.Android/MainActivity.fs
@@ -18,8 +18,7 @@ open Xamarin.Forms.Platform.Android
            Icon = "@drawable/icon",
            Theme = "@style/MainTheme",
            MainLauncher = true,
-           ConfigurationChanges = (ConfigChanges.ScreenSize
-                                   ||| ConfigChanges.Orientation))>]
+           ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsAppCompatActivity()
 
@@ -34,11 +33,6 @@ type MainActivity() =
         Xamarin.Forms.Forms.Init(this, bundle)
         this.LoadApplication(Program.startApplication App.program)
 
-    override this.OnRequestPermissionsResult
-        (
-            requestCode: int,
-            permissions: string [],
-            [<GeneratedEnum>] grantResults: Android.Content.PM.Permission []
-        ) =
+    override this.OnRequestPermissionsResult(requestCode: int, permissions: string[], [<GeneratedEnum>] grantResults: Android.Content.PM.Permission[]) =
         Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults)
         base.OnRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/templates/content/blank/NewApp/App.fs
+++ b/templates/content/blank/NewApp/App.fs
@@ -29,12 +29,11 @@ module App =
                         .centerTextHorizontal()
 
                     (VStack() {
-                        Label($"Count is {model.Count}")
-                            .centerTextHorizontal()
+                        Label($"Count is {model.Count}").centerTextHorizontal()
 
                         Button("Increment", Increment)
                         Button("Decrement", Decrement)
-                     })
+                    })
                         .centerVertical(expand = true)
                 }
             )


### PR DESCRIPTION
README says to use `dotnet new -i` to install templates, but it's deprecated in favor of `dotnet new install`.
This PR updates the READMEs to reflect this deprecation.