### PR TITLE
Remove generic types from WidgetItems and GroupedWidgetItems

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
@@ -10,8 +10,8 @@ type ICollectionView =
 module CollectionView =
     let WidgetKey = Widgets.register<CollectionView>()
 
-    let GroupedItemsSource<'groupData, 'itemData> =
-        Attributes.defineSimpleScalar<GroupedWidgetItems<'groupData, 'itemData>>
+    let GroupedItemsSource =
+        Attributes.defineSimpleScalar<GroupedWidgetItems>
             "CollectionView_GroupedItemsSource"
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
             (fun _ newValueOpt node ->

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -12,8 +12,8 @@ module ListView =
 
     let WidgetKey = Widgets.register<FabulousListView>()
 
-    let GroupedItemsSource<'groupData, 'itemData> =
-        Attributes.defineSimpleScalar<GroupedWidgetItems<'groupData, 'itemData>>
+    let GroupedItemsSource =
+        Attributes.defineSimpleScalar<GroupedWidgetItems>
             "ListView_GroupedItemsSource"
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
             (fun _ newValueOpt node ->

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
@@ -8,8 +8,8 @@ type IItemsView =
     inherit IView
 
 module ItemsView =
-    let ItemsSource<'T> =
-        Attributes.defineSimpleScalar<WidgetItems<'T>>
+    let ItemsSource =
+        Attributes.defineSimpleScalar<WidgetItems>
             "ItemsView_ItemsSource"
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
             (fun _ newValueOpt node ->

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
@@ -7,8 +7,8 @@ type IItemsViewOfCell =
     inherit IView
 
 module ItemsViewOfCell =
-    let ItemsSource<'T> =
-        Attributes.defineSimpleScalar<WidgetItems<'T>>
+    let ItemsSource =
+        Attributes.defineSimpleScalar<WidgetItems>
             "ItemsViewOfCell_ItemsSource"
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
             (fun _ newValueOpt node ->

--- a/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
@@ -10,8 +10,8 @@ type IIndicatorView =
 module IndicatorView =
     let WidgetKey = Widgets.register<IndicatorView>()
 
-    let ItemsSource<'T> =
-        Attributes.defineBindable<WidgetItems<'T>, System.Collections.Generic.IEnumerable<Widget>>
+    let ItemsSource =
+        Attributes.defineBindable<WidgetItems, System.Collections.Generic.IEnumerable<Widget>>
             IndicatorView.ItemsSourceProperty
             (fun modelValue ->
                 seq {

--- a/src/Fabulous.XamarinForms/VirtualizedCollection.fs
+++ b/src/Fabulous.XamarinForms/VirtualizedCollection.fs
@@ -1,6 +1,7 @@
 namespace Fabulous.XamarinForms
 
 open System
+open System.Collections
 open System.Collections.Generic
 open Fabulous
 open Xamarin.Forms
@@ -61,12 +62,12 @@ type WidgetDataTemplateSelector internal (node: IViewNode, templateFn: obj -> Wi
             cache.Add(targetType, dataTemplate)
             dataTemplate
 
-type WidgetItems<'T> =
-    { OriginalItems: IEnumerable<'T>
-      Template: 'T -> Widget }
+type WidgetItems =
+    { OriginalItems: IEnumerable
+      Template: obj -> Widget }
 
-type GroupedWidgetItems<'groupData, 'itemData> =
-    { OriginalItems: IEnumerable<'groupData>
-      HeaderTemplate: 'groupData -> Widget
-      FooterTemplate: ('groupData -> Widget) option
-      ItemTemplate: 'itemData -> Widget }
+type GroupedWidgetItems =
+    { OriginalItems: IEnumerable
+      HeaderTemplate: obj -> Widget
+      FooterTemplate: (obj -> Widget) option
+      ItemTemplate: obj -> Widget }

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -64,7 +64,7 @@ module WidgetHelpers =
 
     let buildItems<'msg, 'marker, 'itemData, 'itemMarker>
         key
-        (attrDef: SimpleScalarAttributeDefinition<WidgetItems<'itemData>>)
+        (attrDef: SimpleScalarAttributeDefinition<WidgetItems>)
         (items: seq<'itemData>)
         (itemTemplate: 'itemData -> WidgetBuilder<'msg, 'itemMarker>)
         =
@@ -72,7 +72,7 @@ module WidgetHelpers =
             let item = unbox<'itemData> item
             (itemTemplate item).Compile()
 
-        let data: WidgetItems<'itemData> =
+        let data: WidgetItems =
             { OriginalItems = items
               Template = template }
 
@@ -80,31 +80,31 @@ module WidgetHelpers =
 
     let buildGroupItems<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'groupData :> seq<'itemData>>
         key
-        (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems<'groupData, 'itemData>>)
+        (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems>)
         (items: seq<'groupData>)
         (groupHeaderTemplate: 'groupData -> WidgetBuilder<'msg, 'groupMarker>)
         (itemTemplate: 'itemData -> WidgetBuilder<'msg, 'itemMarker>)
         (groupFooterTemplate: 'groupData -> WidgetBuilder<'msg, 'groupMarker>)
         =
-        let data: GroupedWidgetItems<'groupData, 'itemData> =
+        let data: GroupedWidgetItems =
             { OriginalItems = items
-              HeaderTemplate = fun d -> (groupHeaderTemplate d).Compile()
-              FooterTemplate = Some(fun d -> (groupFooterTemplate d).Compile())
-              ItemTemplate = fun d -> (itemTemplate d).Compile() }
+              HeaderTemplate = fun d -> (groupHeaderTemplate(unbox d)).Compile()
+              FooterTemplate = Some(fun d -> (groupFooterTemplate(unbox d)).Compile())
+              ItemTemplate = fun d -> (itemTemplate(unbox d)).Compile() }
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))
 
     let buildGroupItemsNoFooter<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'groupData :> seq<'itemData>>
         key
-        (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems<'groupData, 'itemData>>)
+        (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems>)
         (items: seq<'groupData>)
         (groupHeaderTemplate: 'groupData -> WidgetBuilder<'msg, 'groupMarker>)
         (itemTemplate: 'itemData -> WidgetBuilder<'msg, 'itemMarker>)
         =
-        let data: GroupedWidgetItems<'groupData, 'itemData> =
+        let data: GroupedWidgetItems =
             { OriginalItems = items
-              HeaderTemplate = fun d -> (groupHeaderTemplate d).Compile()
+              HeaderTemplate = fun d -> (groupHeaderTemplate(unbox d)).Compile()
               FooterTemplate = None
-              ItemTemplate = fun d -> (itemTemplate d).Compile() }
+              ItemTemplate = fun d -> (itemTemplate(unbox d)).Compile() }
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))


### PR DESCRIPTION
Generic fields in F# are actually compiled as static methods, which means those attribute definitions are recreated on each access and Fabulous can't diff properly. We don't really need those generic types in the first place, so just remove them.

See https://github.com/fabulous-dev/Fabulous.Avalonia/pull/66 for more information.