### PR TITLE
Fix templates by using latest version of Fabulous

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 
 env:
-  VERSION: 2.1.3
+  VERSION: 2.1.4
   CONFIG: Release
   SLN_FILE: Fabulous.XamarinForms.NoSamples.sln
   TEMPLATE_PROJ: templates/Fabulous.XamarinForms.Templates.proj
@@ -35,7 +35,6 @@ jobs:
       run: dotnet test ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-build
     - name: Pack
       run: |
-        find templates -type f -name template.json | xargs sed -i bak "s/FABULOUS_PKG_VERSION/${NIGHTLY_VERSION}/g"
         dotnet pack ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-build --output nupkgs
         dotnet pack ${TEMPLATE_PROJ} -p:Version=${NIGHTLY_VERSION} -p:IsNightlyBuild=true -c ${CONFIG} --output nupkgs
     - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
       run: dotnet test ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-build
     - name: Pack
       run: |
-        find templates -type f -name template.json | xargs sed -i bak "s/FABULOUS_PKG_VERSION/${RELEASE_VERSION}/g"
         dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="${{ steps.changelog_reader.outputs.changes }}" -c ${CONFIG} --no-build --output nupkgs
         dotnet pack ${TEMPLATE_PROJ} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --output nupkgs
     - name: Upload artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [2.1.4] - 2023-01-14
+
+### Changed
+- Updated templates to use Fabulous 2.1.1
+- Make sure Fabulous.XamarinForms use only binary-compatible version of Fabulous
+
 ## [2.1.3] - 2023-01-04
 
 ### Changed
@@ -24,7 +30,8 @@ _No unreleased changes_
 ### Changed
 - Fabulous.XamarinForms has moved from the Fabulous repository to its own repository: [https://github.com/fabulous-dev/Fabulous.XamarinForms](https://github.com/fabulous-dev/Fabulous.XamarinForms)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.3...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.4...HEAD
+[2.1.4]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/fabulous-dev/Fabulous.XamarinForms/releases/tag/v2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,4 @@ _No unreleased changes_
 [2.1.4]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/fabulous-dev/Fabulous.XamarinForms/compare/2.1.1...2.1.2
-[2.1.1]: https://github.com/fabulous-dev/Fabulous.XamarinForms/releases/tag/v2.1.1
+[2.1.1]: https://github.com/fabulous-dev/Fabulous.XamarinForms/releases/tag/2.1.1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="2.1.0" />
+    <PackageVersion Include="Fabulous" Version="2.1.1" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -140,7 +140,7 @@
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" VersionOverride="5.0.0.1874" />
-    <PackageReference Include="Fabulous" />
+    <PackageReference Include="Fabulous" VersionOverride="[2.1.0, 2.2.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/templates/content/blank-vswin/.template.config/template.json
+++ b/templates/content/blank-vswin/.template.config/template.json
@@ -55,7 +55,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgsVersion",
-      "defaultValue": "FABULOUS_PKG_VERSION"
+      "defaultValue": "2.1.1"
     }
   }
 }

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -67,7 +67,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgsVersion",
-      "defaultValue": "FABULOUS_PKG_VERSION"
+      "defaultValue": "2.1.1"
     },
     "FSharpCorePkgVersion": {
       "type": "parameter",


### PR DESCRIPTION
Fixes #5 

Following the separation of the Fabulous and Fabulous.XamarinForms repositories, we forgot to remove the dynamic version of Fabulous package in the Fabulous.XamarinForms templates.
Fix this by using the latest existing version of Fabulous.

Also make sure Fabulous.XamarinForms only uses binary-compatible version of Fabulous by using version boundaries.