### PR TITLE
Exclude jsonbak file from templates package

### DIFF
--- a/templates/Fabulous.XamarinForms.Templates.proj
+++ b/templates/Fabulous.XamarinForms.Templates.proj
@@ -18,6 +18,7 @@ content/*/.ionide/**/*;
 content/*/.cache/**/*;
 content/*/**/obj/**/*;
 content/*/**/bin/**/*;
+content/**/.template.config/template.jsonbak;
     </ExcludeFromPackage>
   </PropertyGroup>
   <PropertyGroup Condition=" $(IsNightlyBuild) != 'true' ">


### PR DESCRIPTION
We are using `sed` to inject the build version into the templates during the CI pipeline.
This command will backup the original file by copying to `template.jsonbak`.

`dotnet pack` the templates will embark this backup file when it's actually not intended.
Exclude it from the packages.