### PR TITLE
Add support for float32 properties which fixes corner radius for Frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Fixed
+
+- Add support for float32 properties which fixes corner radius for Frame (https://github.com/fabulous-dev/Fabulous.XamarinForms/pull/35)
 
 ## [2.2.0] - 2023-01-24
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="2.2.1" />
+    <PackageVersion Include="Fabulous" Version="2.3.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -63,15 +63,6 @@ module SmallScalars =
             let expands = (encoded &&& 0x00000000FFFFFFFFUL) = 1UL
 
             LayoutOptions(alignment, expands)
-            
-    // should this be in Fabulous?        
-    module Float32 =
-        let inline encode (v: float32) : uint64 =
-            v |> float |> BitConverter.DoubleToInt64Bits |> uint64
-
-        let inline decode (encoded: uint64) : float32 =
-            encoded |> int64 |> BitConverter.Int64BitsToDouble |> float32
-        
 
 [<Extension>]
 type SmallScalarExtensions() =
@@ -86,11 +77,7 @@ type SmallScalarExtensions() =
     [<Extension>]
     static member inline WithValue(this: SmallScalarAttributeDefinition<AppThemeValues<FabColor>>, value) =
         this.WithValue(value, SmallScalars.ThemedColor.encode)
-        
-    [<Extension>]
-    static member inline WithValue(this: SmallScalarAttributeDefinition<float32>, value) =
-        this.WithValue(value, SmallScalars.Float32.encode)
-        
+
 module Attributes =
     /// Define an attribute for a BindableProperty
     let inline defineBindable<'modelType, 'valueType>
@@ -126,7 +113,7 @@ module Attributes =
     /// Define a float attribute for a BindableProperty and encode it as a small scalar (8 bytes)
     let inline defineBindableFloat (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float.decode
-        
+
     let inline defineBindableFloat32 (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float32.decode
 

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -63,6 +63,15 @@ module SmallScalars =
             let expands = (encoded &&& 0x00000000FFFFFFFFUL) = 1UL
 
             LayoutOptions(alignment, expands)
+            
+    // should this be in Fabulous?        
+    module Float32 =
+        let inline encode (v: float32) : uint64 =
+            v |> float |> BitConverter.DoubleToInt64Bits |> uint64
+
+        let inline decode (encoded: uint64) : float32 =
+            encoded |> int64 |> BitConverter.Int64BitsToDouble |> float32
+        
 
 [<Extension>]
 type SmallScalarExtensions() =
@@ -77,7 +86,11 @@ type SmallScalarExtensions() =
     [<Extension>]
     static member inline WithValue(this: SmallScalarAttributeDefinition<AppThemeValues<FabColor>>, value) =
         this.WithValue(value, SmallScalars.ThemedColor.encode)
-
+        
+    [<Extension>]
+    static member inline WithValue(this: SmallScalarAttributeDefinition<float32>, value) =
+        this.WithValue(value, SmallScalars.Float32.encode)
+        
 module Attributes =
     /// Define an attribute for a BindableProperty
     let inline defineBindable<'modelType, 'valueType>
@@ -113,6 +126,9 @@ module Attributes =
     /// Define a float attribute for a BindableProperty and encode it as a small scalar (8 bytes)
     let inline defineBindableFloat (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float.decode
+        
+    let inline defineBindableFloat32 (bindableProperty: BindableProperty) =
+        defineSmallBindable bindableProperty SmallScalars.Float32.decode
 
     /// Define a boolean attribute for a BindableProperty and encode it as a small scalar (8 bytes)
     let inline defineBindableBool (bindableProperty: BindableProperty) =

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -114,6 +114,7 @@ module Attributes =
     let inline defineBindableFloat (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float.decode
 
+    /// Define a float32 attribute for a BindableProperty and encode it as a small scalar (8 bytes)
     let inline defineBindableFloat32 (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float32.decode
 

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -140,7 +140,7 @@
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" VersionOverride="5.0.0.1874" />
-    <PackageReference Include="Fabulous" VersionOverride="[2.2.0, 2.3.0)" />
+    <PackageReference Include="Fabulous" VersionOverride="[2.3.0, 2.4.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
@@ -35,8 +35,8 @@ type FrameModifiers =
     /// <summary>Set the corner radius of the frame</summary>
     /// <param name="value">The corner radius of the frame</param>
     [<Extension>]
-    static member inline cornerRadius(this: WidgetBuilder<'msg, #IFrame>, value: float32) =
-        this.AddScalar(Frame.CornerRadius.WithValue(value))
+    static member inline cornerRadius(this: WidgetBuilder<'msg, #IFrame>, value: float) =
+        this.AddScalar(Frame.CornerRadius.WithValue(float32 value))
 
     // <summary>Set the shadow of the frame</summary>
     // <param name="value">Whether the frame has a shadow</param>

--- a/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
@@ -12,7 +12,7 @@ module Frame =
 
     let BorderColor = Attributes.defineBindableAppThemeColor Frame.BorderColorProperty
 
-    let CornerRadius = Attributes.defineBindableFloat Frame.CornerRadiusProperty
+    let CornerRadius = Attributes.defineBindableFloat32 Frame.CornerRadiusProperty
 
     let HasShadow = Attributes.defineBindableBool Frame.HasShadowProperty
 
@@ -35,7 +35,7 @@ type FrameModifiers =
     /// <summary>Set the corner radius of the frame</summary>
     /// <param name="value">The corner radius of the frame</param>
     [<Extension>]
-    static member inline cornerRadius(this: WidgetBuilder<'msg, #IFrame>, value: float) =
+    static member inline cornerRadius(this: WidgetBuilder<'msg, #IFrame>, value: float32) =
         this.AddScalar(Frame.CornerRadius.WithValue(value))
 
     // <summary>Set the shadow of the frame</summary>

--- a/templates/content/blank-vswin/.template.config/template.json
+++ b/templates/content/blank-vswin/.template.config/template.json
@@ -55,7 +55,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgVersion",
-      "defaultValue": "2.2.0"
+      "defaultValue": "2.3.0"
     },
     "FabulousXFPkgVersion": {
       "type": "parameter",


### PR DESCRIPTION
The following view code adapted from the Counter example
```fsharp
    let view model =
        Application(
            ContentPage(
                "Stuff",
                Frame(
                    Button("Hello from Fabulous Xamarin.Forms, .NET 6.0 and F# 6.0!", Increment)
                        .verticalOptions(LayoutOptions.Center)
                        .horizontalOptions(LayoutOptions.Center)
                        
                ).cornerRadius(50.)
                 .borderColor(Color.Red.ToFabColor())
            ).padding(Thickness(5.))
        )
```
 does not set the corner radius on the Frame:

![image](https://user-images.githubusercontent.com/17431305/225273353-78429cc3-ed93-463f-92cb-f8b7fcb31b61.png)

With the changes in this PR (and changing the corner radius value to 50.f) the Frame corner radius is set:

![image](https://user-images.githubusercontent.com/17431305/225274451-848539e2-2874-4711-87e9-84ca76a5c54e.png)

I found that if the value was narrowed to a float32 in `defineSmallBindable` then the corner radius was set as expected:
```fsharp
            | ValueSome v -> if bindableProperty.PropertyName = "CornerRadius" then
                                target.SetValue(bindableProperty,150.f)
                             else
                                target.SetValue(bindableProperty, v))
```
If the value is changed to a float then the corner radius is not set.

I did not establish why XF does not accept the value as a float.

The PR contains codecs for float32 which should possibly be in the Fabulous core project?

Note: there are only 4 properties in XF that are of type C# float/F# float32.
